### PR TITLE
Limit pressure to be non-negative to allow SummationDensity with free surfaces

### DIFF
--- a/examples/simple_convection_2d.jl
+++ b/examples/simple_convection_2d.jl
@@ -23,7 +23,7 @@ end
 smoothing_length = 0.12
 smoothing_kernel = SchoenbergCubicSplineKernel{2}()
 search_radius = Pixie.compact_support(smoothing_kernel, smoothing_length)
-semi = SPHSemidiscretization{2}(particle_masses, ContinuityDensity(),
+semi = SPHSemidiscretization{2}(particle_masses, SummationDensity(),
                                 StateEquationCole(10.0, 7, 1000.0, 1.0, background_pressure=1.0),
                                 smoothing_kernel, smoothing_length,
                                 viscosity=ArtificialViscosityMonaghan(1.0, 2.0),
@@ -31,7 +31,8 @@ semi = SPHSemidiscretization{2}(particle_masses, ContinuityDensity(),
                               #   neighborhood_search=nothing)
 
 tspan = (0.0, 20.0)
-ode = semidiscretize(semi, particle_coordinates, particle_velocities, particle_densities, tspan)
+ode = semidiscretize(semi, particle_coordinates, particle_velocities, tspan)
+# ode = semidiscretize(semi, particle_coordinates, particle_velocities, particle_densities, tspan)
 
 alive_callback = AliveCallback(alive_interval=100)
 

--- a/src/sph/sph.jl
+++ b/src/sph/sph.jl
@@ -147,9 +147,8 @@ function semidiscretize(semi::SPHSemidiscretization{NDIMS, ELTYPE, ContinuityDen
 end
 
 
-function compute_quantities(u, semi)
-    # Note that @threaded makes this slower with ContinuityDensity
-    for particle in eachparticle(semi)
+function compute_quantities(u, semi::SPHSemidiscretization{NDIMS, ELTYPE, SummationDensity}) where {NDIMS, ELTYPE}
+    @threaded for particle in eachparticle(semi)
         compute_quantities_per_particle(u, particle, semi)
     end
 end
@@ -176,11 +175,14 @@ end
     pressure[particle] = state_equation(density[particle])
 end
 
-@inline function compute_quantities_per_particle(u, particle, semi::SPHSemidiscretization{NDIMS, ELTYPE, ContinuityDensity}) where {NDIMS, ELTYPE}
+function compute_quantities(u, semi::SPHSemidiscretization{NDIMS, ELTYPE, ContinuityDensity}) where {NDIMS, ELTYPE}
     @unpack density_calculator, state_equation, cache = semi
     @unpack pressure = cache
 
-    pressure[particle] = state_equation(get_particle_density(u, cache, density_calculator, particle))
+    # Note that @threaded makes this slower with ContinuityDensity
+    for particle in eachparticle(semi)
+        pressure[particle] = state_equation(get_particle_density(u, cache, density_calculator, particle))
+    end
 end
 
 

--- a/src/sph/state_equations.jl
+++ b/src/sph/state_equations.jl
@@ -27,7 +27,8 @@ end
 function (state_equation::StateEquationIdealGas)(density)
     @unpack sound_speed, reference_density, reference_pressure, background_pressure = state_equation
 
-    return sound_speed^2 * (density - reference_density) + reference_pressure - background_pressure
+    # Limit pressure to be non-negative to avoid negative pressures at free surfaces
+    return max(sound_speed^2 * (density - reference_density) + reference_pressure - background_pressure, 0.0)
 end
 
 
@@ -68,6 +69,7 @@ end
 function (state_equation::StateEquationCole)(density)
     @unpack sound_speed, gamma, reference_density, reference_pressure, background_pressure = state_equation
 
-    return reference_density * sound_speed^2 / gamma * ((density / reference_density)^gamma - 1) +
-        reference_pressure - background_pressure
+    # Limit pressure to be non-negative to avoid negative pressures at free surfaces
+    return max(reference_density * sound_speed^2 / gamma * ((density / reference_density)^gamma - 1) +
+        reference_pressure - background_pressure, 0.0)
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -32,6 +32,7 @@ timer() = main_timer
 # but without `try ... finally ... end` block. Thus, it's not exception-safe,
 # but it also avoids some related performance problems. Since we do not use
 # exception handling in Pixie, that's not really an issue.
+#
 # Copied from [Trixi.jl](https://github.com/trixi-framework/Trixi.jl).
 macro pixie_timeit(timer_output, label, expr)
     timeit_block = quote
@@ -68,8 +69,11 @@ might be provided by other packages such as [Polyester.jl](https://github.com/Ju
     This macro does not necessarily work for general `for` loops. For example,
     it does not necessarily support general iterables such as `eachline(filename)`.
 
-Some discussion can be found at https://discourse.julialang.org/t/overhead-of-threads-threads/53964
-and https://discourse.julialang.org/t/threads-threads-with-one-thread-how-to-remove-the-overhead/58435.
+Some discussion can be found at
+[https://discourse.julialang.org/t/overhead-of-threads-threads/53964](https://discourse.julialang.org/t/overhead-of-threads-threads/53964)
+and
+[https://discourse.julialang.org/t/threads-threads-with-one-thread-how-to-remove-the-overhead/58435](https://discourse.julialang.org/t/threads-threads-with-one-thread-how-to-remove-the-overhead/58435).
+
 Copied from [Trixi.jl](https://github.com/trixi-framework/Trixi.jl).
 """
 macro threaded(expr)


### PR DESCRIPTION
This makes it possible to run free surface simulations without using `ContinuityDensity`.