### PR TITLE
Fix `SolutionSavingCallback`

### DIFF
--- a/examples/dam_break_2d.jl
+++ b/examples/dam_break_2d.jl
@@ -91,17 +91,13 @@ tspan = (0.0, 3.0)
 ode = semidiscretize(semi, particle_coordinates, particle_velocities, particle_densities, tspan)
 
 alive_callback = AliveCallback(alive_interval=100)
-saved_values, saving_callback = SolutionSavingCallback(saveat=0.0:0.02:20.0,
-                                                       index=(u, t, integrator) -> Pixie.eachparticle(integrator.p))
-
-callbacks = CallbackSet(alive_callback, saving_callback)
 
 # Use a Runge-Kutta method with automatic (error based) time step size control
 # Enable threading of the RK method for better performance on multiple threads
 sol = solve(ode, RDPK3SpFSAL49(thread=OrdinaryDiffEq.True()),
             dt=1e-4, # Initial guess of the time step to prevent too large guesses
             abstol=1.0e-4, reltol=1.0e-4, # Tighter tolerance to prevent instabilities, use 2e-5 for spacing 0.004
-            saveat=0.02, callback=callbacks);
+            save_everystep=false, callback=alive_callback);
 
 # Move right boundary
 for y in 1:n_boundaries_vertical
@@ -115,9 +111,14 @@ end
 tspan = (0.0, 5.7 / sqrt(9.81))
 ode = semidiscretize(semi, view(sol[end], 1:2, :), view(sol[end], 3:4, :), view(sol[end], 5, :), tspan)
 
+saved_values, saving_callback = SolutionSavingCallback(saveat=0.0:0.02:20.0,
+                                                       index=(u, t, integrator) -> Pixie.eachparticle(integrator.p))
+
+callbacks = CallbackSet(alive_callback, saving_callback)
+
 # Use a Runge-Kutta method with automatic (error based) time step size control
 # Enable threading of the RK method for better performance on multiple threads
 sol = solve(ode, RDPK3SpFSAL49(thread=OrdinaryDiffEq.True()),
             dt=1e-4, # Initial guess of the time step to prevent too large guesses
             abstol=1.0e-4, reltol=1.0e-4, # Tighter tolerance to prevent instabilities
-            saveat=0.02, callback=callbacks);
+            save_everystep=false, callback=callbacks);

--- a/examples/dam_break_3d.jl
+++ b/examples/dam_break_3d.jl
@@ -121,9 +121,13 @@ tspan = (0.0, 5.0)
 ode = semidiscretize(semi, particle_coordinates, particle_velocities, particle_densities, tspan)
 
 alive_callback = AliveCallback(alive_interval=10)
+saved_values, saving_callback = SolutionSavingCallback(saveat=0.0:0.02:20.0,
+                                                       index=(u, t, integrator) -> Pixie.eachparticle(integrator.p))
+
+callbacks = CallbackSet(alive_callback, saving_callback)
 
 # Use a Runge-Kutta method with automatic (error based) time step size control
 # Enable threading of the RK method for better performance on multiple threads
 sol = solve(ode, RDPK3SpFSAL49(thread=OrdinaryDiffEq.True()),
             dt=1e-4, # Initial guess of the time step to prevent too large guesses
-            saveat=0.02, callback=alive_callback);
+            save_everystep=false, callback=callbacks);

--- a/examples/rectangular_tank_2d.jl
+++ b/examples/rectangular_tank_2d.jl
@@ -87,7 +87,10 @@ tspan = (0.0, 5.0)
 ode = semidiscretize(semi, particle_coordinates, particle_velocities, particle_densities, tspan)
 
 alive_callback = AliveCallback(alive_interval=10)
+saved_values, saving_callback = SolutionSavingCallback(saveat=0.0:0.02:20.0)
+
+callbacks = CallbackSet(alive_callback, saving_callback)
 
 # Use a Runge-Kutta method with automatic (error based) time step size control
 # Enable threading of the RK method for better performance on multiple threads
-sol = solve(ode, RDPK3SpFSAL49(thread=OrdinaryDiffEq.True()), dt=1e-5, saveat=0.02, callback=alive_callback);
+sol = solve(ode, RDPK3SpFSAL49(thread=OrdinaryDiffEq.True()), dt=1e-5, save_everystep=false, callback=alive_callback);

--- a/examples/simple_convection_2d.jl
+++ b/examples/simple_convection_2d.jl
@@ -42,4 +42,4 @@ callbacks = CallbackSet(alive_callback, saving_callback)
 
 # Use a Runge-Kutta method with automatic (error based) time step size control
 # Enable threading of the RK method for better performance on multiple threads
-sol = solve(ode, RDPK3SpFSAL49(thread=OrdinaryDiffEq.True()), saveat=0.02, callback=callbacks);
+sol = solve(ode, RDPK3SpFSAL49(thread=OrdinaryDiffEq.True()), save_everystep=false, callback=callbacks);

--- a/examples/simple_convection_3d.jl
+++ b/examples/simple_convection_3d.jl
@@ -32,5 +32,8 @@ tspan = (0.0, 5.0)
 ode = semidiscretize(semi, particle_coordinates, particle_velocities, tspan)
 
 alive_callback = AliveCallback(alive_interval=20)
+saved_values, saving_callback = SolutionSavingCallback(saveat=0.0:0.02:20.0)
 
-sol = solve(ode, RDPK3SpFSAL49(), saveat=0.04, callback=alive_callback);
+callbacks = CallbackSet(alive_callback, saving_callback)
+
+sol = solve(ode, RDPK3SpFSAL49(), save_everystep=false, callback=callbacks);

--- a/examples/simple_dam_break_2d.jl
+++ b/examples/simple_dam_break_2d.jl
@@ -62,8 +62,7 @@ tspan = (0.0, 5.0)
 ode = semidiscretize(semi, particle_coordinates, particle_velocities, particle_densities, tspan)
 
 alive_callback = AliveCallback(alive_interval=100)
-saved_values, saving_callback = SolutionSavingCallback(saveat=0.0:0.02:20.0,
-                                                       index=(u, t, integrator) -> Pixie.eachparticle(integrator.p))
+saved_values, saving_callback = SolutionSavingCallback(saveat=0.0:0.02:20.0)
 
 callbacks = CallbackSet(alive_callback, saving_callback)
 
@@ -72,4 +71,4 @@ callbacks = CallbackSet(alive_callback, saving_callback)
 sol = solve(ode, RDPK3SpFSAL49(thread=OrdinaryDiffEq.True()),
             dt=1e-4, # Initial guess of the time step to prevent too large guesses
             # abstol=1.0e-6, reltol=1.0e-6, # Tighter tolerance to prevent instabilities
-            saveat=0.02, callback=callbacks);
+            save_everystep=false, callback=callbacks);

--- a/src/callbacks/solution_saving.jl
+++ b/src/callbacks/solution_saving.jl
@@ -36,16 +36,33 @@ struct ExtractQuantities{CQ}
 end
 
 
-function (extract_quantities::ExtractQuantities)(u, t, integrator)
+function (extract_quantities::ExtractQuantities)(u_cache, t, integrator)
     semi = integrator.p
     @unpack density_calculator, cache = semi
     @unpack custom_quantities = extract_quantities
 
+    # The SavingCallback does not insert tstops, so u had to be interpolated.
+    # However, only u has been interpolated, but not semi.cache. To compute the correct
+    # cache, we have to call rhs! with the correct u again (u_cache).
+    # The interpolation has been done in-place by DiffEqCallbacks, using the cache
+    # first(get_tmp_cache(integrator)), which is passed as u_cache here, so we can modify
+    # u_cache without consequences.
+    # Thus, we can pass u_cache to rhs! as du.
+    # Of course, we have to save the current u before we overwrite u_cache.
+    # This allocation is not a problem, since we have to return allocated values anyway
+    # (not a view to u_cache).
+    u = copy(u_cache)
+
+    # Call rhs! to compute the correct cache (pressures, etc.)
+    rhs!(u_cache, u, semi, t)
+
     result = Dict(
-        # Note that these have to be allocated and no views can be used here
-        :coordinates   => u[1:ndims(semi), :],
-        :velocity      => u[(ndims(semi)+1):(2*ndims(semi)), :],
-        :density       => extract_density(u, cache, density_calculator),
+        # Note that we have to allocate here and can't use views.
+        # See https://diffeq.sciml.ai/stable/features/callback_library/#saving_callback.
+        # However, u has already been allocated above, so we can use views to u.
+        :coordinates   => view(u, 1:ndims(semi), :),
+        :velocity      => view(u, (ndims(semi)+1):(2*ndims(semi)), :),
+        :density       => extract_density(u, cache, density_calculator, semi),
         :pressure      => copy(cache.pressure)
     )
 
@@ -56,5 +73,5 @@ function (extract_quantities::ExtractQuantities)(u, t, integrator)
     return result
 end
 
-extract_density(u, cache, ::SummationDensity) = copy(cache.density)
-extract_density(u, cache, ::ContinuityDensity) = u[end, :]
+extract_density(u, cache, ::SummationDensity, semi) = copy(cache.density)
+extract_density(u, cache, ::ContinuityDensity, semi) = view(u, 2*ndims(semi) + 1, :)


### PR DESCRIPTION
In my last PR, I used `DiffEqCallbacks.SavingCallback` instead of a plain `DiscreteCallback` to

1. be able to save the solution at specific times without introducing additional `tstop`s and thus additional time steps, while still
2. being able to save the solution in regular intervals (simulation time) and not just every `n` time steps, so that animations can be created properly with adaptive time stepping.

`DiffEqCallbacks.SavingCallback` does not introduce additional `tstop`s, but instead uses the interpolator that comes with most solvers to interpolate between time steps.
However, only `u` is interpolated and not the internal caches of the semidiscretization, where e.g. the pressure is stored. Thus, the saved pressure (and density with `SummationDensity`) was incorrect.
Now, instead of introducing extra time steps (with all stages), I still use the interpolation approach, but added one `rhs!` evaluation to recalculate the caches with the interpolated `u`.