### PR TITLE
Fix saving callback (again)

### DIFF
--- a/src/Pixie.jl
+++ b/src/Pixie.jl
@@ -5,7 +5,7 @@ using LinearAlgebra: norm
 using Morton: cartesian2morton
 using Polyester: @batch
 using Printf: @printf
-using SciMLBase: CallbackSet, DiscreteCallback, ODEProblem, u_modified!
+using SciMLBase: CallbackSet, DiscreteCallback, ODEProblem, u_modified!, get_tmp_cache
 using StaticArrays: SVector
 using ThreadingUtilities
 using TimerOutputs: TimerOutput, TimerOutputs, print_timer, reset_timer!


### PR DESCRIPTION
The variable `u_cache` was not always a pointer to the cache, but sometimes a pointer to `integrator.u`.
Thus, overwriting `u_cache` modified `integrator.u` whenever `u` was not interpolated, tampering with the actual solution.