### PR TITLE
Cancel redundant CI tests automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Seems to work:
<img width="669" alt="image" src="https://user-images.githubusercontent.com/44124897/211806365-83650d01-6a93-4d18-9af5-0ad881946ba3.png">
