### PR TITLE
[Hotfix] Change `destats` to `stats` and require OrdinaryDiffEq 6.49 for testing

### DIFF
--- a/src/callbacks/info.jl
+++ b/src/callbacks/info.jl
@@ -45,7 +45,7 @@ function (info_callback::InfoCallback)(u, t, integrator)
     @unpack interval = info_callback
 
     return interval != 0 &&
-           integrator.destats.naccept % interval == 0 ||
+           integrator.stats.naccept % interval == 0 ||
            isfinished(integrator)
 end
 
@@ -54,7 +54,7 @@ function (info_callback::InfoCallback)(integrator)
     if isfinished(integrator)
         println("─"^100)
         println("Pixie simulation finished.  Final time: ", integrator.t,
-                "  Time steps: ", integrator.destats.naccept, " (accepted), ",
+                "  Time steps: ", integrator.stats.naccept, " (accepted), ",
                 integrator.iter, " (total)")
         println("─"^100)
         println()
@@ -67,7 +67,7 @@ function (info_callback::InfoCallback)(integrator)
     else
         runtime_absolute = 1.0e-9 * (time_ns() - info_callback.start_time)
         @printf("#timesteps: %6d │ Δt: %.4e │ sim. time: %.4e │ run time: %.4e s\n",
-                integrator.destats.naccept, integrator.dt, integrator.t, runtime_absolute)
+                integrator.stats.naccept, integrator.dt, integrator.t, runtime_absolute)
     end
 
     # Tell OrdinaryDiffEq that u has not been modified

--- a/src/callbacks/solution_saving.jl
+++ b/src/callbacks/solution_saving.jl
@@ -111,12 +111,12 @@ function (solution_callback::SolutionSavingCallback)(u, t, integrator)
     @unpack interval, save_final_solution = solution_callback
 
     # With error-based step size control, some steps can be rejected. Thus,
-    #   `integrator.iter >= integrator.destats.naccept`
+    #   `integrator.iter >= integrator.stats.naccept`
     #    (total #steps)       (#accepted steps)
     # We need to check the number of accepted steps since callbacks are not
     # activated after a rejected step.
-    return interval > 0 && (((integrator.destats.naccept % interval == 0) &&
-             !(integrator.destats.naccept == 0 && integrator.iter > 0)) ||
+    return interval > 0 && (((integrator.stats.naccept % interval == 0) &&
+             !(integrator.stats.naccept == 0 && integrator.iter > 0)) ||
             (save_final_solution && isfinished(integrator)))
 end
 
@@ -138,7 +138,7 @@ function (solution_callback::SolutionSavingCallback)(integrator)
     return nothing
 end
 
-get_iter(::Integer, integrator) = integrator.destats.naccept
+get_iter(::Integer, integrator) = integrator.stats.naccept
 function get_iter(dt::AbstractFloat, integrator)
     # Basically `(t - tspan[1]) / dt` as `Int`.
     Int(div(integrator.t - first(integrator.sol.prob.tspan), dt, RoundNearest))

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -4,3 +4,6 @@ OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+OrdinaryDiffEq = "6.49"


### PR DESCRIPTION
This fixes the CI errors, but requires us all to update to OrdinaryDiffEq 6.49.