### PR TITLE
run CI not on every push but only on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 # Cancel redundant CI tests automatically
 concurrency:


### PR DESCRIPTION
The current setup runs GitHub actions twice when pushing to a development branch for a PR, see 

![image](https://user-images.githubusercontent.com/12693098/226103451-b5117783-f66b-47ca-93cd-f2b68bade176.png)

The change lets CI only run on `push` events to `main`.