### PR TITLE
avoid computing hashes twice in `particles_in_cell`

### DIFF
--- a/src/sph/neighborhood_search.jl
+++ b/src/sph/neighborhood_search.jl
@@ -144,12 +144,9 @@ end
 @inline function particles_in_cell(cell_index, neighborhood_search)
     @unpack hashtable, empty_vector = neighborhood_search
 
-    if haskey(hashtable, cell_index)
-        return hashtable[cell_index]
-    end
-
-    # Reuse empty vector to avoid allocations
-    return empty_vector
+    # Return an empty vector when `cell_index` is not a key of `hastable` and
+    # reuse the empty vector to avoid allocations
+    return get(hashtable, cell_index, empty_vector)
 end
 
 @inline function get_cell_coords(coords, neighborhood_search)


### PR DESCRIPTION
This is another minor performance improvement. I used again the following code:
```julia
julia> using OrdinaryDiffEq, TrixiParticles

julia> trixi_include("examples/fluid/dam_break_2d.jl", tspan = (0.0, 0.03));

julia> sol = solve(ode, RDPK3SpFSAL49(),
                   abstol=1e-6, # Default abstol is 1e-6 (may need to be tuned to prevent boundary penetration)
                   reltol=1e-5, # Default reltol is 1e-3 (may need to be tuned to prevent boundary penetration)
                   dtmax=1e-2, # Limit stepsize to prevent crashing
                   save_everystep=false, callback=callbacks);
```

Current `main`:
```
 ────────────────────────────────────────────────────────────────────────────────────────────
             TrixiParticles.jl                      Time                    Allocations      
                                           ───────────────────────   ────────────────────────
             Tot / % measured:                  1.88s /  98.9%           19.0MiB /  93.9%    

 Section                           ncalls     time    %tot     avg     alloc    %tot      avg
 ────────────────────────────────────────────────────────────────────────────────────────────
 kick!                                399    1.82s   97.8%  4.55ms   10.9MiB   61.0%  27.9KiB
   container interaction              399    1.50s   80.9%  3.76ms     0.00B    0.0%    0.00B
   update containers and nhs          399    312ms   16.8%   782μs   10.9MiB   61.0%  27.9KiB
     update nhs                       399    165ms    8.9%   413μs   10.9MiB   61.0%  27.9KiB
     compute boundary pressure        399    119ms    6.4%   298μs     0.00B    0.0%    0.00B
     ~update containers and nhs~      399   28.3ms    1.5%  71.0μs   1.47KiB    0.0%    3.77B
   gravity and damping                399    996μs    0.1%  2.50μs     0.00B    0.0%    0.00B
   reset ∂v/∂t                        399    694μs    0.0%  1.74μs     0.00B    0.0%    0.00B
   ~kick!~                            399    241μs    0.0%   604ns   2.94KiB    0.0%    7.54B
 save solution                          2   37.4ms    2.0%  18.7ms   6.91MiB   38.8%  3.46MiB
 drift!                               399   2.16ms    0.1%  5.42μs   1.47KiB    0.0%    3.77B
   velocity                           399   1.53ms    0.1%  3.84μs     0.00B    0.0%    0.00B
   reset ∂u/∂t                        399    540μs    0.0%  1.35μs     0.00B    0.0%    0.00B
   ~drift!~                           399   90.6μs    0.0%   227ns   1.47KiB    0.0%    3.77B
 update nhs                             1    534μs    0.0%   534μs   27.9KiB    0.2%  27.9KiB
 compute boundary pressure              1    291μs    0.0%   291μs     0.00B    0.0%    0.00B
 ────────────────────────────────────────────────────────────────────────────────────────────
```

This PR:
```
 ────────────────────────────────────────────────────────────────────────────────────────────
             TrixiParticles.jl                      Time                    Allocations      
                                           ───────────────────────   ────────────────────────
             Tot / % measured:                  1.69s /  98.8%           19.0MiB /  93.9%    

 Section                           ncalls     time    %tot     avg     alloc    %tot      avg
 ────────────────────────────────────────────────────────────────────────────────────────────
 kick!                                399    1.63s   97.6%  4.10ms   10.9MiB   61.0%  27.9KiB
   container interaction              399    1.34s   80.0%  3.36ms     0.00B    0.0%    0.00B
   update containers and nhs          399    293ms   17.5%   734μs   10.9MiB   61.0%  27.9KiB
     update nhs                       399    151ms    9.0%   378μs   10.9MiB   61.0%  27.9KiB
     compute boundary pressure        399    114ms    6.8%   285μs     0.00B    0.0%    0.00B
     ~update containers and nhs~      399   28.0ms    1.7%  70.2μs   1.47KiB    0.0%    3.77B
   gravity and damping                399    980μs    0.1%  2.46μs     0.00B    0.0%    0.00B
   reset ∂v/∂t                        399    709μs    0.0%  1.78μs     0.00B    0.0%    0.00B
   ~kick!~                            399    212μs    0.0%   532ns   2.94KiB    0.0%    7.54B
 save solution                          2   36.6ms    2.2%  18.3ms   6.91MiB   38.8%  3.46MiB
 drift!                               399   2.10ms    0.1%  5.27μs   1.47KiB    0.0%    3.77B
   velocity                           399   1.50ms    0.1%  3.77μs     0.00B    0.0%    0.00B
   reset ∂u/∂t                        399    510μs    0.0%  1.28μs     0.00B    0.0%    0.00B
   ~drift!~                           399   90.4μs    0.0%   227ns   1.47KiB    0.0%    3.77B
 update nhs                             1    526μs    0.0%   526μs   27.9KiB    0.2%  27.9KiB
 compute boundary pressure              1    282μs    0.0%   282μs     0.00B    0.0%    0.00B
 ────────────────────────────────────────────────────────────────────────────────────────────
```