### PR TITLE
Add test directory to coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Process coverage results
         uses: julia-actions/julia-processcoverage@v1
         with:
-          directories: src,examples
+          directories: src,test,examples
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
All test code should be fully covered. If not, that means that we forgot to include a test file. The coverage report should include the test directory, so that we can immediately spot something like this.