### PR TITLE
checking for overlapping particles

### DIFF
--- a/src/semidiscretization/semidiscretization.jl
+++ b/src/semidiscretization/semidiscretization.jl
@@ -176,7 +176,7 @@ function semidiscretize(semi, tspan; check_overlapping=true)
         write_v0!(v0_container, container)
 
         if check_overlapping && overlapping_particles(u0_container, Val(ndims(container)))
-            @warn "There are overlapping particles in $container."
+            @warn "There are overlapping particles in container $container_index."
         end
     end
 
@@ -211,10 +211,10 @@ function restart_with!(semi, sol)
     return semi
 end
 
-function overlapping_particles(coords, ::Val{NDIMS}) where {NDIMS}
+function overlapping_particles(coords, ::Val{NDIMS}; search_radius=1e-6) where {NDIMS}
     n_particles = size(coords, 2)
 
-    nhs = SpatialHashingSearch{NDIMS}(1e-6, n_particles)
+    nhs = SpatialHashingSearch{NDIMS}(search_radius, n_particles)
 
     initialize!(nhs, coords)
 
@@ -226,7 +226,7 @@ function overlapping_particles(coords, ::Val{NDIMS}) where {NDIMS}
 
             pos_diff = particle_coords - neighbor_coords
             distance2 = dot(pos_diff, pos_diff)
-            if particle != neighbor && distance2 < 1e-3
+            if particle != neighbor && distance2 < sqrt(search_radius)
                 return true
             end
         end

--- a/src/semidiscretization/semidiscretization.jl
+++ b/src/semidiscretization/semidiscretization.jl
@@ -145,7 +145,7 @@ digest_containers(boundary_condition::Tuple) = boundary_condition
 
 Create an `ODEProblem` from the semidiscretization with the specified `tspan`.
 """
-function semidiscretize(semi, tspan)
+function semidiscretize(semi, tspan; check_overlapping=true)
     @unpack particle_containers, neighborhood_searches = semi
 
     @assert all(container -> eltype(container) === eltype(particle_containers[1]),
@@ -175,7 +175,7 @@ function semidiscretize(semi, tspan)
         write_u0!(u0_container, container)
         write_v0!(v0_container, container)
 
-        if overlapping_particles(u0_container, Val(ndims(container)))
+        if check_overlapping && overlapping_particles(u0_container, Val(ndims(container)))
             @warn "There are overlapping particles in $container."
         end
     end
@@ -213,6 +213,7 @@ end
 
 function overlapping_particles(coords, ::Val{NDIMS}) where {NDIMS}
     n_particles = size(coords, 2)
+
     nhs = SpatialHashingSearch{NDIMS}(1e-6, n_particles)
 
     initialize!(nhs, coords)


### PR DESCRIPTION
This PR emerged from the discussion in #115.
Checking for each container but not for the whole simulation domain. For the latter it might be useful to add a `wrap_u` function which wraps the whole `u_ode` vector.  This is only valid under the condition that `u_ode` stores only the coordinates and nothing else (which is the case so far). 

Does it make sense to add such a function? Maybe it could be useful in the future? 