### PR TITLE
Add `@autoinfiltrate` for simple, ad-hoc interactive debugging

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -275,7 +275,7 @@ See also: [Infiltrator.jl](https://github.com/JuliaDebug/Infiltrator.jl)
     API of TrixiParticles.jl, and it thus can altered (or be removed) at any time without it being
     considered a breaking change.
 """
-macro autoinfiltrate(condition = true)
+macro autoinfiltrate(condition=true)
     pkgid = Base.PkgId(Base.UUID("5903a43b-9cc3-4c30-8d17-598619ec4e9b"), "Infiltrator")
     if !haskey(Base.loaded_modules, pkgid)
         try
@@ -286,19 +286,16 @@ macro autoinfiltrate(condition = true)
     end
     i = get(Base.loaded_modules, pkgid, nothing)
     lnn = LineNumberNode(__source__.line, __source__.file)
-  
+
     if i === nothing
-        return Expr(
-            :macrocall,
-            Symbol("@warn"),
-            lnn,
-            "Could not load Infiltrator.")
+        return Expr(:macrocall,
+                    Symbol("@warn"),
+                    lnn,
+                    "Could not load Infiltrator.")
     end
-  
-    return Expr(
-        :macrocall,
-        Expr(:., i, QuoteNode(Symbol("@infiltrate"))),
-        lnn,
-        esc(condition)
-    )
+
+    return Expr(:macrocall,
+                Expr(:., i, QuoteNode(Symbol("@infiltrate"))),
+                lnn,
+                esc(condition))
 end


### PR DESCRIPTION
Same as https://github.com/trixi-framework/Trixi.jl/pull/1465

This allows one to have the Infiltrator.jl package installed anywhere in the Julia environment stack and then just add `@autoinfiltrate` to any function in TrixiParticles.jl. When the macro location is hit, it will drop you into an interactive session that allows you to inspect the local variables (see also the Infiltrator.jl [docs](https://github.com/JuliaDebug/Infiltrator.jl)).

I don't know if this is useful for you, but since I added it for Trix.jl, I thought I might add it here as well.