### PR TITLE
Remove Codecov annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
       - name: Run unit and integration tests
         uses: julia-actions/julia-runtest@v1
         with:
-          annotate: true
           coverage: true
         env:
           TRIXIPARTICLES_TEST: unitandintegration


### PR DESCRIPTION
@sloede is right, this is more annoying than helpful.
Maybe we can think about adding annotations again once we've reached a good overall coverage.