### PR TITLE
Update JuliaFormatter and use YAS style nesting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,6 +1,9 @@
 # Use SciML style: https://github.com/SciML/SciMLStyle
 style = "sciml"
 
+# Python style alignment. See https://github.com/domluna/JuliaFormatter.jl/pull/732.
+yas_style_nesting = true
+
 # Align struct fields for better readability of large struct definitions
 align_struct_field = true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           version: '1'
       - name: Apply JuliaFormatter and check format
         run: |
-          julia -e 'using Pkg; Pkg.add(name="JuliaFormatter", version="1.0.32")'
+          julia -e 'using Pkg; Pkg.add("JuliaFormatter")'
           julia -e 'using JuliaFormatter; !format(".", verbose=true) &&
             error("Code not properly formatted")'
       - name: Build package


### PR DESCRIPTION
Now that https://github.com/domluna/JuliaFormatter.jl/pull/732 is merged, we can undo #173 and use the latest version of JuliaFormatter again.