### PR TITLE
fix example files

### DIFF
--- a/examples/fluid/moving_wall_2d.jl
+++ b/examples/fluid/moving_wall_2d.jl
@@ -40,7 +40,7 @@ tank = RectangularTank(particle_spacing, (water_width, water_height),
 boundary_particle_spacing = particle_spacing / beta_wall
 
 # Move right boundary
-wall_position = tank.n_particles_per_dimension[1] * particle_spacing
+wall_position = tank.fluid_size[1]
 n_wall_particles_y = size(tank.face_indices[2], 2) * beta_wall
 
 wall = RectangularShape(boundary_particle_spacing,

--- a/examples/fsi/dam_break_gate_2d.jl
+++ b/examples/fsi/dam_break_gate_2d.jl
@@ -111,10 +111,10 @@ boundary_model_tank = BoundaryModelDummyParticles(tank.boundary.density,
 boundary_model_gate = BoundaryModelDummyParticles(gate.density, gate.mass, state_equation,
                                                   AdamiPressureExtrapolation(),
                                                   smoothing_kernel, smoothing_length)
-#K_gate = 9.81 * water_height
-#boundary_model_gate = BoundaryModelMonaghanKajtar(K_gate, beta_gate,
-#                                                  fluid_particle_spacing / beta_gate,
-#                                                  gate.mass)
+# K_gate = 9.81 * water_height
+# boundary_model_gate = BoundaryModelMonaghanKajtar(K_gate, beta_gate,
+#                                                   fluid_particle_spacing / beta_gate,
+#                                                   gate.mass)
 
 hydrodynamic_densites = water_density * ones(size(solid.density))
 hydrodynamic_masses = hydrodynamic_densites * solid_particle_spacing^2


### PR DESCRIPTION
Due to #193 the `moving_wall_2d.jl` example is buggy:
![image](https://github.com/trixi-framework/TrixiParticles.jl/assets/73897120/85af23f2-384e-4e83-8d12-192e83e6e17d)

This PR fixes it and also change the boundary model of the `dam_break_gate_2d.jl` to the `BoundaryModelDummyParticles`.