### PR TITLE
Rename `SpatialHashingSearch` to `GridNeighborhoodSearch`

### DIFF
--- a/examples/fluid/accelerated_tank_2d.jl
+++ b/examples/fluid/accelerated_tank_2d.jl
@@ -65,7 +65,7 @@ boundary_system = BoundarySPHSystem(tank.boundary, boundary_model,
 # ==== Simulation
 
 semi = Semidiscretization(fluid_system, boundary_system,
-                          neighborhood_search=SpatialHashingSearch)
+                          neighborhood_search=GridNeighborhoodSearch)
 
 tspan = (0.0, 2.0)
 ode = semidiscretize(semi, tspan)

--- a/examples/fluid/dam_break_2d.jl
+++ b/examples/fluid/dam_break_2d.jl
@@ -73,7 +73,7 @@ boundary_system = BoundarySPHSystem(tank.boundary, boundary_model)
 # ==== Simulation
 
 semi = Semidiscretization(fluid_system, boundary_system,
-                          neighborhood_search=SpatialHashingSearch,
+                          neighborhood_search=GridNeighborhoodSearch,
                           damping_coefficient=1e-5)
 
 tspan = (0.0, 3.0)
@@ -108,7 +108,7 @@ tspan = (0.0, 5.7 / sqrt(9.81))
 restart_with!(semi, sol)
 
 semi = Semidiscretization(fluid_system, boundary_system,
-                          neighborhood_search=SpatialHashingSearch)
+                          neighborhood_search=GridNeighborhoodSearch)
 ode = semidiscretize(semi, tspan)
 
 saving_callback = SolutionSavingCallback(dt=0.02)

--- a/examples/fluid/dam_break_2d_corrections.jl
+++ b/examples/fluid/dam_break_2d_corrections.jl
@@ -86,7 +86,7 @@ for correction_name in keys(correction_dict)
     reset_wall!(tank, reset_faces, positions)
 
     semi = Semidiscretization(particle_system, boundary_system,
-                              neighborhood_search=SpatialHashingSearch,
+                              neighborhood_search=GridNeighborhoodSearch,
                               damping_coefficient=1e-5)
 
     tspan = (0.0, 3.0)
@@ -122,7 +122,7 @@ for correction_name in keys(correction_dict)
     restart_with!(semi, sol)
 
     semi = Semidiscretization(particle_system, boundary_system,
-                              neighborhood_search=SpatialHashingSearch)
+                              neighborhood_search=GridNeighborhoodSearch)
     ode = semidiscretize(semi, tspan)
 
     saving_callback = SolutionSavingCallback(dt=0.02,

--- a/examples/fluid/dam_break_3d.jl
+++ b/examples/fluid/dam_break_3d.jl
@@ -67,7 +67,7 @@ boundary_system = BoundarySPHSystem(tank.boundary, boundary_model)
 # ==== Simulation
 
 semi = Semidiscretization(fluid_system, boundary_system,
-                          neighborhood_search=SpatialHashingSearch,
+                          neighborhood_search=GridNeighborhoodSearch,
                           damping_coefficient=1e-5)
 
 tspan = (0.0, 3.0)
@@ -102,7 +102,7 @@ tspan = (0.0, 5.7 / sqrt(9.81))
 restart_with!(semi, sol)
 
 semi = Semidiscretization(fluid_system, boundary_system,
-                          neighborhood_search=SpatialHashingSearch)
+                          neighborhood_search=GridNeighborhoodSearch)
 ode = semidiscretize(semi, tspan)
 
 saving_callback = SolutionSavingCallback(dt=0.02)

--- a/examples/fluid/falling_water_column_2d.jl
+++ b/examples/fluid/falling_water_column_2d.jl
@@ -63,7 +63,7 @@ boundary_system = BoundarySPHSystem(tank.boundary, boundary_model)
 # ==== Simulation
 
 semi = Semidiscretization(fluid_system, boundary_system,
-                          neighborhood_search=SpatialHashingSearch)
+                          neighborhood_search=GridNeighborhoodSearch)
 
 tspan = (0.0, 2.0)
 ode = semidiscretize(semi, tspan)

--- a/examples/fluid/moving_wall_2d.jl
+++ b/examples/fluid/moving_wall_2d.jl
@@ -84,7 +84,7 @@ boundary_system_wall = BoundarySPHSystem(wall, boundary_model_wall,
 tspan = (0.0, 2.0)
 
 semi = Semidiscretization(fluid_system, boundary_system_tank, boundary_system_wall,
-                          neighborhood_search=SpatialHashingSearch)
+                          neighborhood_search=GridNeighborhoodSearch)
 
 ode = semidiscretize(semi, tspan)
 

--- a/examples/fluid/periodic_channel_2d.jl
+++ b/examples/fluid/periodic_channel_2d.jl
@@ -63,7 +63,7 @@ boundary_system = BoundarySPHSystem(tank.boundary, boundary_model)
 # ==== Simulation
 
 semi = Semidiscretization(fluid_system, boundary_system,
-                          neighborhood_search=SpatialHashingSearch,
+                          neighborhood_search=GridNeighborhoodSearch,
                           periodic_box_min_corner=[0.0, -0.24],
                           periodic_box_max_corner=[0.96, 0.72])
 

--- a/examples/fluid/rectangular_tank_2d.jl
+++ b/examples/fluid/rectangular_tank_2d.jl
@@ -59,7 +59,7 @@ boundary_system = BoundarySPHSystem(tank.boundary, boundary_model)
 # ==== Simulation
 
 semi = Semidiscretization(fluid_system, boundary_system,
-                          neighborhood_search=SpatialHashingSearch,
+                          neighborhood_search=GridNeighborhoodSearch,
                           damping_coefficient=1e-5)
 
 tspan = (0.0, 2.0)

--- a/examples/fsi/dam_break_2d.jl
+++ b/examples/fsi/dam_break_2d.jl
@@ -139,7 +139,7 @@ solid_system = TotalLagrangianSPHSystem(solid,
 
 # Relaxing of the fluid without solid
 semi = Semidiscretization(fluid_system, boundary_system,
-                          neighborhood_search=SpatialHashingSearch,
+                          neighborhood_search=GridNeighborhoodSearch,
                           damping_coefficient=1e-5)
 
 tspan_relaxing = (0.0, 3.0)
@@ -172,7 +172,7 @@ tspan = (0.0, 1.0)
 restart_with!(semi, sol)
 
 semi = Semidiscretization(fluid_system, boundary_system, solid_system,
-                          neighborhood_search=SpatialHashingSearch)
+                          neighborhood_search=GridNeighborhoodSearch)
 ode = semidiscretize(semi, tspan)
 
 saving_callback = SolutionSavingCallback(dt=0.02)

--- a/examples/fsi/dam_break_gate_2d.jl
+++ b/examples/fsi/dam_break_gate_2d.jl
@@ -161,7 +161,7 @@ solid_system = TotalLagrangianSPHSystem(solid,
 # Relaxing of the fluid without solid
 semi = Semidiscretization(fluid_system, boundary_system_tank,
                           boundary_system_gate,
-                          neighborhood_search=SpatialHashingSearch)
+                          neighborhood_search=GridNeighborhoodSearch)
 
 tspan = (0.0, 3.0)
 ode = semidiscretize(semi, tspan)
@@ -192,7 +192,7 @@ restart_with!(semi, sol)
 
 semi = Semidiscretization(fluid_system, boundary_system_tank,
                           boundary_system_gate, solid_system,
-                          neighborhood_search=SpatialHashingSearch)
+                          neighborhood_search=GridNeighborhoodSearch)
 
 ode = semidiscretize(semi, tspan)
 

--- a/examples/fsi/falling_spheres_2d.jl
+++ b/examples/fsi/falling_spheres_2d.jl
@@ -117,7 +117,7 @@ solid_system_2 = TotalLagrangianSPHSystem(sphere_2,
 
 semi = Semidiscretization(fluid_system, boundary_system, solid_system_1,
                           solid_system_2,
-                          neighborhood_search=SpatialHashingSearch)
+                          neighborhood_search=GridNeighborhoodSearch)
 
 tspan = (0.0, 2.0)
 ode = semidiscretize(semi, tspan)

--- a/examples/fsi/falling_water_column_2d.jl
+++ b/examples/fsi/falling_water_column_2d.jl
@@ -100,7 +100,7 @@ solid_system = TotalLagrangianSPHSystem(solid,
 # ==== Simulation
 
 semi = Semidiscretization(fluid_system, solid_system,
-                          neighborhood_search=SpatialHashingSearch)
+                          neighborhood_search=GridNeighborhoodSearch)
 
 tspan = (0.0, 1.0)
 ode = semidiscretize(semi, tspan)

--- a/examples/solid/oscillating_beam_2d.jl
+++ b/examples/solid/oscillating_beam_2d.jl
@@ -56,7 +56,7 @@ solid_system = TotalLagrangianSPHSystem(solid,
 # ==========================================================================================
 # ==== Simulation
 
-semi = Semidiscretization(solid_system, neighborhood_search=SpatialHashingSearch)
+semi = Semidiscretization(solid_system, neighborhood_search=GridNeighborhoodSearch)
 tspan = (0.0, 5.0)
 
 ode = semidiscretize(semi, tspan)

--- a/src/TrixiParticles.jl
+++ b/src/TrixiParticles.jl
@@ -43,7 +43,7 @@ export StateEquationIdealGas, StateEquationCole
 export ArtificialViscosityMonaghan, ViscosityAdami
 export BoundaryModelMonaghanKajtar, BoundaryModelDummyParticles, AdamiPressureExtrapolation
 export BoundaryMovement
-export SpatialHashingSearch
+export GridNeighborhoodSearch
 export examples_dir, trixi_include
 export trixi2vtk
 export RectangularTank, RectangularShape, SphereShape

--- a/src/general/initial_condition.jl
+++ b/src/general/initial_condition.jl
@@ -126,7 +126,7 @@ function find_too_close_particles(coords1, coords2, max_distance)
     NDIMS = size(coords1, 1)
     result = Int[]
 
-    nhs = SpatialHashingSearch{NDIMS}(max_distance, size(coords2, 2))
+    nhs = GridNeighborhoodSearch{NDIMS}(max_distance, size(coords2, 2))
     TrixiParticles.initialize!(nhs, coords2)
 
     # We are modifying the vector `result`, so this cannot be parallel

--- a/src/general/semidiscretization.jl
+++ b/src/general/semidiscretization.jl
@@ -8,7 +8,7 @@ the keyword argument `neighborhood_search`. A value of `nothing` means no neighb
 
 # Examples
 ```julia
-semi = Semidiscretization(fluid_system, boundary_system; neighborhood_search=SpatialHashingSearch, damping_coefficient=nothing)
+semi = Semidiscretization(fluid_system, boundary_system; neighborhood_search=GridNeighborhoodSearch, damping_coefficient=nothing)
 ```
 """
 struct Semidiscretization{S, RU, RV, NS, DC}
@@ -84,12 +84,12 @@ function create_neighborhood_search(system, neighbor, ::Val{nothing},
                                              min_corner=min_corner, max_corner=max_corner)
 end
 
-function create_neighborhood_search(system, neighbor, ::Val{SpatialHashingSearch},
+function create_neighborhood_search(system, neighbor, ::Val{GridNeighborhoodSearch},
                                     min_corner, max_corner)
     radius = compact_support(system, neighbor)
-    search = SpatialHashingSearch{ndims(system)}(radius, nparticles(neighbor),
-                                                 min_corner=min_corner,
-                                                 max_corner=max_corner)
+    search = GridNeighborhoodSearch{ndims(system)}(radius, nparticles(neighbor),
+                                                   min_corner=min_corner,
+                                                   max_corner=max_corner)
 
     # Initialize neighborhood search
     initialize!(search, initial_coordinates(neighbor))

--- a/src/neighborhood_search/neighborhood_search.jl
+++ b/src/neighborhood_search/neighborhood_search.jl
@@ -106,4 +106,4 @@ end
 end
 
 include("trivial_nhs.jl")
-include("spatial_hashing_search.jl")
+include("grid_nhs.jl")

--- a/test/neighborhood_search/grid_nhs.jl
+++ b/test/neighborhood_search/grid_nhs.jl
@@ -1,4 +1,4 @@
-@testset verbose=true "SpatialHashingSearch" begin
+@testset verbose=true "GridNeighborhoodSearch" begin
     @testset "Coordinate Limits" begin
         # Test the threshold for very large and very small coordinates.
         coords1 = [Inf, -Inf]
@@ -25,7 +25,7 @@
         radius = particle_spacing
 
         # Create neighborhood search
-        nhs1 = SpatialHashingSearch{2}(radius, nparticles)
+        nhs1 = GridNeighborhoodSearch{2}(radius, nparticles)
 
         coords_fun(i) = coordinates1[:, i]
         TrixiParticles.initialize!(nhs1, coords_fun)
@@ -50,7 +50,7 @@
         neighbors3 = sort(collect(TrixiParticles.eachneighbor(particle_position2, nhs1)))
 
         # Double search radius
-        nhs2 = SpatialHashingSearch{2}(2 * radius, size(coordinates1, 2))
+        nhs2 = GridNeighborhoodSearch{2}(2 * radius, size(coordinates1, 2))
         TrixiParticles.initialize!(nhs2, coords_fun)
 
         # Get each neighbor in double search radius
@@ -92,7 +92,7 @@
         radius = particle_spacing
 
         # Create neighborhood search
-        nhs1 = SpatialHashingSearch{3}(radius, nparticles)
+        nhs1 = GridNeighborhoodSearch{3}(radius, nparticles)
 
         coords_fun(i) = coordinates1[:, i]
         TrixiParticles.initialize!(nhs1, coords_fun)
@@ -133,8 +133,8 @@
                   -0.12 -0.05 -0.09 0.15 0.39]
 
         # 3 x 6 cells
-        nhs = SpatialHashingSearch{2}(0.1, size(coords, 2),
-                                      min_corner=[-0.1, -0.2], max_corner=[0.2, 0.4])
+        nhs = GridNeighborhoodSearch{2}(0.1, size(coords, 2),
+                                        min_corner=[-0.1, -0.2], max_corner=[0.2, 0.4])
 
         TrixiParticles.initialize!(nhs, coords)
 

--- a/test/neighborhood_search/neighborhood_search.jl
+++ b/test/neighborhood_search/neighborhood_search.jl
@@ -1,2 +1,2 @@
 include("trivial_nhs.jl")
-include("spatial_hashing_search.jl")
+include("grid_nhs.jl")


### PR DESCRIPTION
The old name came from the paper that originally inspired me to implement this kind of NHS, but it's usually just referred to as "grid-based neighborhood search", which makes the new name a lot more self-explanatory.

Depends on #209.