### PR TITLE
Fix `SummationDensity` for boundaries

### DIFF
--- a/src/general/semidiscretization.jl
+++ b/src/general/semidiscretization.jl
@@ -113,12 +113,6 @@ end
     return compact_support(system, system.boundary_model, neighbor)
 end
 
-@inline function compact_support(system::Union{TotalLagrangianSPHSystem, BoundarySPHSystem},
-                                 neighbor::BoundarySPHSystem)
-    # This NHS is never used
-    return 0.0
-end
-
 @inline function compact_support(system, model, neighbor)
     # Use the compact support of the fluid for solid-fluid interaction
     return compact_support(neighbor, system)


### PR DESCRIPTION
Boundaries did not use other boundary particles in the density summation.