### PR TITLE
Make n-body fast again

### DIFF
--- a/src/general/semidiscretization.jl
+++ b/src/general/semidiscretization.jl
@@ -408,7 +408,12 @@ function system_interaction!(dv_ode, v_ode, u_ode, semi)
             u_neighbor = wrap_u(u_ode, neighbor_index, neighbor, semi)
             neighborhood_search = neighborhood_searches[system_index][neighbor_index]
 
-            timer_str = "$(timer_name(system))$system_index-$(timer_name(neighbor))$neighbor_index"
+            # Avoid allocations from string construction when no timers are used
+            timer_str = if timeit_debug_enabled()
+                "$(timer_name(system))$system_index-$(timer_name(neighbor))$neighbor_index"
+            else
+                ""
+            end
             @trixi_timeit timer() timer_str begin
                 interact!(dv, v_system, u_system, v_neighbor, u_neighbor,
                           neighborhood_search, system, neighbor)


### PR DESCRIPTION
This caused a massive amount of allocations, slowing down the n-body benchmark by a factor of 6.