### PR TITLE
qualify `create_cache` functions

### DIFF
--- a/src/schemes/boundary/dummy_particles/dummy_particles.jl
+++ b/src/schemes/boundary/dummy_particles/dummy_particles.jl
@@ -93,8 +93,8 @@ struct BoundaryModelDummyParticles{ELTYPE <: Real, SE, DC, K, V, C}
 
         n_particles = length(initial_density)
 
-        cache = (; create_cache(viscosity, n_particles, ndims(smoothing_kernel))...,
-                 create_cache(initial_density, density_calculator)...)
+        cache = (; create_cache_model(viscosity, n_particles, ndims(smoothing_kernel))...,
+                 create_cache_model(initial_density, density_calculator)...)
 
         new{eltype(initial_density), typeof(state_equation),
             typeof(density_calculator), typeof(smoothing_kernel), typeof(viscosity),
@@ -298,29 +298,29 @@ end
            grad_kernel
 end
 
-function create_cache(initial_density,
-                      ::Union{SummationDensity, PressureMirroring, PressureZeroing})
+function create_cache_model(initial_density,
+                            ::Union{SummationDensity, PressureMirroring, PressureZeroing})
     density = copy(initial_density)
 
     return (; density)
 end
 
-function create_cache(initial_density, ::ContinuityDensity)
+function create_cache_model(initial_density, ::ContinuityDensity)
     return (; initial_density)
 end
 
-function create_cache(initial_density, ::AdamiPressureExtrapolation)
+function create_cache_model(initial_density, ::AdamiPressureExtrapolation)
     density = copy(initial_density)
     volume = similar(initial_density)
 
     return (; density, volume)
 end
 
-function create_cache(viscosity::NoViscosity, n_particles, n_dims)
+function create_cache_model(viscosity::NoViscosity, n_particles, n_dims)
     return (;)
 end
 
-function create_cache(viscosity::ViscosityAdami, n_particles, n_dims)
+function create_cache_model(viscosity::ViscosityAdami, n_particles, n_dims)
     ELTYPE = eltype(viscosity.nu)
 
     wall_velocity = zeros(ELTYPE, n_dims, n_particles)

--- a/src/schemes/boundary/system.jl
+++ b/src/schemes/boundary/system.jl
@@ -19,7 +19,7 @@ struct BoundarySPHSystem{BM, NDIMS, ELTYPE <: Real, M, C} <: System{NDIMS}
         NDIMS = size(coordinates, 1)
         ismoving = zeros(Bool, 1)
 
-        cache = create_cache(movement, inititial_condition)
+        cache = create_cache_boundary(movement, inititial_condition)
 
         return new{typeof(model), NDIMS, eltype(coordinates), typeof(movement),
                    typeof(cache)}(coordinates, model, movement,
@@ -58,9 +58,9 @@ struct BoundaryMovement{MF, IM}
     end
 end
 
-create_cache(::Nothing, inititial_condition) = (;)
+create_cache_boundary(::Nothing, inititial_condition) = (;)
 
-function create_cache(::BoundaryMovement, inititial_condition)
+function create_cache_boundary(::BoundaryMovement, inititial_condition)
     initial_coordinates = copy(inititial_condition.coordinates)
     velocity = similar(inititial_condition.velocity)
     acceleration = similar(inititial_condition.velocity)

--- a/src/schemes/fluid/weakly_compressible_sph/system.jl
+++ b/src/schemes/fluid/weakly_compressible_sph/system.jl
@@ -68,10 +68,10 @@ struct WeaklyCompressibleSPHSystem{NDIMS, ELTYPE <: Real, DC, SE, K, V, COR, C} 
             throw(ArgumentError("`ShepardKernelCorrection` cannot be used with `ContinuityDensity`"))
         end
 
-        cache = create_cache(n_particles, ELTYPE, density_calculator)
+        cache = create_cache_wcsph(n_particles, ELTYPE, density_calculator)
         cache = (;
-                 create_cache(correction, initial_condition.density, NDIMS, n_particles)...,
-                 cache...)
+                 create_cache_wcsph(correction, initial_condition.density, NDIMS,
+                                    n_particles)..., cache...)
 
         return new{NDIMS, ELTYPE, typeof(density_calculator), typeof(state_equation),
                    typeof(smoothing_kernel), typeof(viscosity),
@@ -83,24 +83,24 @@ struct WeaklyCompressibleSPHSystem{NDIMS, ELTYPE <: Real, DC, SE, K, V, COR, C} 
     end
 end
 
-create_cache(correction, density, NDIMS, nparticles) = (;)
+create_cache_wcsph(correction, density, NDIMS, nparticles) = (;)
 
-function create_cache(::ShepardKernelCorrection, density, NDIMS, n_particles)
+function create_cache_wcsph(::ShepardKernelCorrection, density, NDIMS, n_particles)
     (; kernel_correction_coefficient=similar(density))
 end
 
-function create_cache(::KernelGradientCorrection, density, NDIMS, n_particles)
+function create_cache_wcsph(::KernelGradientCorrection, density, NDIMS, n_particles)
     dw_gamma = Array{Float64}(undef, NDIMS, n_particles)
     (; kernel_correction_coefficient=similar(density), dw_gamma)
 end
 
-function create_cache(n_particles, ELTYPE, ::SummationDensity)
+function create_cache_wcsph(n_particles, ELTYPE, ::SummationDensity)
     density = Vector{ELTYPE}(undef, n_particles)
 
     return (; density)
 end
 
-function create_cache(n_particles, ELTYPE, ::ContinuityDensity)
+function create_cache_wcsph(n_particles, ELTYPE, ::ContinuityDensity)
     # Density in this case is added to the end of 'v' and allocated by modifying 'v_nvariables'.
     return (;)
 end


### PR DESCRIPTION
According to the discussion in #277, this is my suggestion.

The methods of `create_cache` before that: 
```julia
julia> methods(TrixiParticles.create_cache)
# 12 methods for generic function "create_cache" from TrixiParticles:
  [1] create_cache(initial_density, ::Union{PressureMirroring, PressureZeroing, SummationDensity})
     @ TrixiParticles.jl/src/schemes/boundary/dummy_particles/dummy_particles.jl:301
  [2] create_cache(viscosity::ViscosityAdami, n_particles, n_dims)
     @ TrixiParticles.jl/src/schemes/boundary/dummy_particles/dummy_particles.jl:323
  [3] create_cache(::BoundaryMovement, inititial_condition)
     @ TrixiParticles.jl/src/schemes/boundary/system.jl:63
  [4] create_cache(::ShepardKernelCorrection, density, NDIMS, n_particles)
     @ TrixiParticles.jl/src/schemes/fluid/weakly_compressible_sph/system.jl:88
  [5] create_cache(::KernelGradientCorrection, density, NDIMS, n_particles)
     @ TrixiParticles.jl/src/schemes/fluid/weakly_compressible_sph/system.jl:92
  [6] create_cache(initial_density, ::ContinuityDensity)
     @ TrixiParticles.jl/src/schemes/boundary/dummy_particles/dummy_particles.jl:308
  [7] create_cache(initial_density, ::AdamiPressureExtrapolation)
     @ TrixiParticles.jl/src/schemes/boundary/dummy_particles/dummy_particles.jl:312
  [8] create_cache(viscosity::TrixiParticles.NoViscosity, n_particles, n_dims)
     @ TrixiParticles.jl/src/schemes/boundary/dummy_particles/dummy_particles.jl:319
  [9] create_cache(::Nothing, inititial_condition)
     @ TrixiParticles.jl/src/schemes/boundary/system.jl:61
 [10] create_cache(n_particles, ELTYPE, ::SummationDensity)
     @ TrixiParticles.jl/src/schemes/fluid/weakly_compressible_sph/system.jl:97
 [11] create_cache(n_particles, ELTYPE, ::ContinuityDensity)
     @ TrixiParticles.jl/src/schemes/fluid/weakly_compressible_sph/system.jl:103
 [12] create_cache(correction, density, NDIMS, nparticles)
     @ TrixiParticles.jl/src/schemes/fluid/weakly_compressible_sph/system.jl:86
```