### PR TITLE
Micro optimization: switch order of operations in `kernel_grad`

### DIFF
--- a/src/general/smoothing_kernels.jl
+++ b/src/general/smoothing_kernels.jl
@@ -52,7 +52,7 @@ abstract type SmoothingKernel{NDIMS} end
 @inline Base.ndims(::SmoothingKernel{NDIMS}) where {NDIMS} = NDIMS
 
 @inline function kernel_grad(kernel, pos_diff, distance, h)
-    return kernel_deriv(kernel, distance, h) * pos_diff / distance
+    return kernel_deriv(kernel, distance, h) / distance * pos_diff
 end
 
 @inline function corrected_kernel_grad(kernel, pos_diff, distance, h, correction, system,


### PR DESCRIPTION
main:
```
julia> @btime TrixiParticles.kernel_grad($smoothing_kernel, $pos_diff, $distance, $smoothing_length);
  4.700 ns (0 allocations: 0 bytes)
```
With this PR:
```
julia> @btime TrixiParticles.kernel_grad($smoothing_kernel, $pos_diff, $distance, $smoothing_length);
  3.850 ns (0 allocations: 0 bytes)
```

In a simulation:
main:
```
julia> trixi_include("examples/fluid/dam_break_3d.jl", tspan=(0.0, 0.1));
[...]

julia> @btime TrixiParticles.interact!($dv_ode, $v_ode, $u_ode, $fluid_system, $fluid_system, $semi);
  7.698 ms (0 allocations: 0 bytes)
```

This PR:
```
julia> @btime TrixiParticles.interact!($dv_ode, $v_ode, $u_ode, $fluid_system, $fluid_system, $semi);
  7.553 ms (0 allocations: 0 bytes)
```

It's not much, but at least something.