### PR TITLE
Ignore examples folder in coverage results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Process coverage results
         uses: julia-actions/julia-processcoverage@v1
         with:
-          directories: src,test,examples
+          directories: src,test
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
We're only running unit tests with coverage (at least for now, since example tests with coverage are way too expensive), so including the examples folder in the coverage report offsets our coverage by 4%.