### PR TITLE
Circle segment support for `RoundSphere`

### DIFF
--- a/src/setups/sphere_shape.jl
+++ b/src/setups/sphere_shape.jl
@@ -129,7 +129,7 @@ struct VoxelSphere end
 """
     RoundSphere(; start_angle=0.0, end_angle=2π)
 
-Construct a sphere (segment) by nesting perfectly round concentric spheres.
+Construct a sphere (or sphere segment) by nesting perfectly round concentric spheres.
 The resulting ball will be perfectly round, but will not have a regular inner structure.
 
 # Keywords
@@ -137,22 +137,25 @@ The resulting ball will be perfectly round, but will not have a regular inner st
                  beginning point of the segment. The default is set to `0.0` representing
                  the positive x-axis.
 - `end_angle`: The ending angle of the sphere segment in radians. It defines the termination
-               point of the segment. The default is set to `2π`, completing a full sphere.
+               point of the segment. The default is set to `2pi`, completing a full sphere.
 
 !!! note "Usage"
     See [`SphereShape`](@ref) on how to use this.
 
 !!! warning "Warning"
-    The sphere segment is intended for 2D geometries and hollow spheres. If used in a
-    3D context or for a full circle, results may not be accurate.
+    The sphere segment is intended for 2D geometries and hollow spheres. If used for filled
+    spheres or in a 3D context, results may not be accurate.
 """
 struct RoundSphere{AR}
     angle_range::AR
+
     function RoundSphere(; start_angle=0.0, end_angle=2pi)
         if start_angle > end_angle
-            throw(ArgumentError("`end_angle` should be greater than `start_angle`."))
+            throw(ArgumentError("`end_angle` should be greater than `start_angle`"))
         end
+
         angle_range = (start_angle, end_angle)
+
         new{typeof(angle_range)}(angle_range)
     end
 end
@@ -257,6 +260,7 @@ end
 
 function round_sphere(sphere, particle_spacing, radius, center::SVector{2})
     (; angle_range) = sphere
+
     theta = angle_range[2] - angle_range[1]
     n_particles = round(Int, theta * radius / particle_spacing)
 
@@ -270,7 +274,7 @@ function round_sphere(sphere, particle_spacing, radius, center::SVector{2})
         t = LinRange(angle_range[1], angle_range[2], n_particles + 1)
     else
         # Remove the last particle at 2pi, which overlaps with the first at 0
-        t = LinRange(0, 2pi, n_particles + 1)[1:(end - 1)]
+        t = LinRange(angle_range[1], angle_range[2], n_particles + 1)[1:(end - 1)]
     end
 
     particle_coords = Array{Float64, 2}(undef, 2, length(t))

--- a/test/setups/sphere_shape.jl
+++ b/test/setups/sphere_shape.jl
@@ -41,7 +41,7 @@
                         sphere_type=RoundSphere(),
                         n_layers=3, layer_outwards=true),
             SphereShape(particle_spacing, radius, (3.0, -4), 1000.0,
-                        sphere_type=RoundSphere(start_angle=π, end_angle=1.5π),
+                        sphere_type=RoundSphere(start_angle=pi, end_angle=1.5pi),
                         n_layers=3, layer_outwards=true),
         ]
 


### PR DESCRIPTION
`sphere = SphereShape(0.1, 2.0, (2.0, 0.0), 1000.0, n_layers=3, sphere_type=RoundSphere()`

With `cutout_min=(0.0, -2.0), cutout_max=(4.0, 0.0))`
![image](https://github.com/trixi-framework/TrixiParticles.jl/assets/73897120/9757b7a7-0b9b-4837-a8f7-8f5dbf719911)


With `RoundSphere(end_angle=pi)`
![image](https://github.com/trixi-framework/TrixiParticles.jl/assets/73897120/5e7827c0-ab52-4fdc-85fd-880e408880ba)

With `RoundSphere(start_angle=pi, end_angle=1.5pi)`
![image](https://github.com/trixi-framework/TrixiParticles.jl/assets/73897120/337ebef8-8527-4a00-ad8d-0e373ad523f4)

3D `RoundSphere(end_angle=pi)`: 
![image](https://github.com/trixi-framework/TrixiParticles.jl/assets/73897120/78243391-2643-4c15-ac10-5392397baf78)

3D: `RoundSphere(end_angle=1.5pi)` pacman
![image](https://github.com/trixi-framework/TrixiParticles.jl/assets/73897120/86b5bd2d-fe60-4202-a1e8-5bd7e87c2d85)
