### PR TITLE
Simplify dispatch of boundary models

### DIFF
--- a/src/schemes/boundary/dummy_particles/dummy_particles.jl
+++ b/src/schemes/boundary/dummy_particles/dummy_particles.jl
@@ -74,7 +74,7 @@ We provide five options to compute the boundary density and pressure, determined
   In: Computers, Materials and Continua 5 (2007), pages 173-184.
   [doi: 10.3970/cmc.2007.005.173](https://doi.org/10.3970/cmc.2007.005.173)
 """
-struct BoundaryModelDummyParticles{ELTYPE <: Real, SE, DC, K, V, C}
+struct BoundaryModelDummyParticles{DC, ELTYPE <: Real, SE, K, V, C}
     pressure           :: Vector{ELTYPE}
     hydrodynamic_mass  :: Vector{ELTYPE}
     state_equation     :: SE
@@ -96,8 +96,8 @@ struct BoundaryModelDummyParticles{ELTYPE <: Real, SE, DC, K, V, C}
         cache = (; create_cache_model(viscosity, n_particles, ndims(smoothing_kernel))...,
                  create_cache_model(initial_density, density_calculator)...)
 
-        new{eltype(initial_density), typeof(state_equation),
-            typeof(density_calculator), typeof(smoothing_kernel), typeof(viscosity),
+        new{typeof(density_calculator), eltype(initial_density),
+            typeof(state_equation), typeof(smoothing_kernel), typeof(viscosity),
             typeof(cache)}(pressure, hydrodynamic_mass, state_equation, density_calculator,
                            smoothing_kernel, smoothing_length, viscosity, cache)
     end

--- a/src/schemes/boundary/rhs.jl
+++ b/src/schemes/boundary/rhs.jl
@@ -1,34 +1,19 @@
 # Interaction of boundary  with other systems
 function interact!(dv, v_particle_system, u_particle_system,
                    v_neighbor_system, u_neighbor_system, neighborhood_search,
-                   particle_system::BoundarySPHSystem,
-                   neighbor_system)
+                   particle_system::BoundarySPHSystem, neighbor_system)
     # TODO Solids and moving boundaries should be considered in the continuity equation
     return dv
 end
 
-# Boundary-fluid interaction with dummy particles model
+# For dummy particles with `ContinuityDensity`, solve the continuity equation
 function interact!(dv, v_particle_system, u_particle_system,
                    v_neighbor_system, u_neighbor_system, neighborhood_search,
-                   particle_system::BoundarySPHSystem{<:BoundaryModelDummyParticles},
+                   particle_system::BoundarySPHSystem{
+                                                      <:BoundaryModelDummyParticles{
+                                                                                    ContinuityDensity
+                                                                                    }},
                    neighbor_system::FluidSystem)
-    (; density_calculator) = particle_system.boundary_model
-
-    interact!(dv, v_particle_system, u_particle_system,
-              v_neighbor_system, u_neighbor_system, neighborhood_search,
-              particle_system, neighbor_system, density_calculator)
-end
-
-function interact!(dv, v_particle_system, u_particle_system,
-                   v_neighbor_system, u_neighbor_system, neighborhood_search,
-                   particle_system::BoundarySPHSystem, neighbor_system, density_calculator)
-    return dv
-end
-
-# With `ContinuityDensity` solve the continuity equation
-function interact!(dv, v_particle_system, u_particle_system,
-                   v_neighbor_system, u_neighbor_system, neighborhood_search,
-                   particle_system::BoundarySPHSystem, neighbor_system, ::ContinuityDensity)
     (; boundary_model) = particle_system
 
     system_coords = current_coordinates(u_particle_system, particle_system)

--- a/src/schemes/solid/total_lagrangian_sph/system.jl
+++ b/src/schemes/solid/total_lagrangian_sph/system.jl
@@ -180,23 +180,15 @@ end
 
 timer_name(::TotalLagrangianSPHSystem) = "solid"
 
-@inline function v_nvariables(system::TotalLagrangianSPHSystem{
-                                                               <:BoundaryModelMonaghanKajtar
-                                                               })
+@inline function v_nvariables(system::TotalLagrangianSPHSystem)
     return ndims(system)
 end
 
 @inline function v_nvariables(system::TotalLagrangianSPHSystem{
-                                                               <:BoundaryModelDummyParticles
+                                                               <:BoundaryModelDummyParticles{
+                                                                                             ContinuityDensity
+                                                                                             }
                                                                })
-    return v_nvariables(system, system.boundary_model.density_calculator)
-end
-
-@inline function v_nvariables(system::TotalLagrangianSPHSystem, density_calculator)
-    return ndims(system)
-end
-
-@inline function v_nvariables(system::TotalLagrangianSPHSystem, ::ContinuityDensity)
     return ndims(system) + 1
 end
 
@@ -386,21 +378,12 @@ function write_v0!(v0, system::TotalLagrangianSPHSystem)
     return v0
 end
 
-function write_v0!(v0, ::BoundaryModelMonaghanKajtar, system::TotalLagrangianSPHSystem)
+function write_v0!(v0, model, system::TotalLagrangianSPHSystem)
     return v0
 end
 
-function write_v0!(v0, ::BoundaryModelDummyParticles, system::TotalLagrangianSPHSystem)
-    (; density_calculator) = system.boundary_model
-
-    write_v0!(v0, density_calculator, system)
-end
-
-function write_v0!(v0, density_calculator, system::TotalLagrangianSPHSystem)
-    return v0
-end
-
-function write_v0!(v0, ::ContinuityDensity, system::TotalLagrangianSPHSystem)
+function write_v0!(v0, ::BoundaryModelDummyParticles{ContinuityDensity},
+                   system::TotalLagrangianSPHSystem)
     (; cache) = system.boundary_model
     (; initial_density) = cache
 


### PR DESCRIPTION
I did not touch `pressure_acceleration`, which will be changed in #299. With this PR, one level of dispatch can be removed in #299.