### PR TITLE
Apply new release of JuliaFormatter

### DIFF
--- a/src/schemes/boundary/rhs.jl
+++ b/src/schemes/boundary/rhs.jl
@@ -9,10 +9,7 @@ end
 # For dummy particles with `ContinuityDensity`, solve the continuity equation
 function interact!(dv, v_particle_system, u_particle_system,
                    v_neighbor_system, u_neighbor_system, neighborhood_search,
-                   particle_system::BoundarySPHSystem{
-                                                      <:BoundaryModelDummyParticles{
-                                                                                    ContinuityDensity
-                                                                                    }},
+                   particle_system::BoundarySPHSystem{<:BoundaryModelDummyParticles{ContinuityDensity}},
                    neighbor_system::FluidSystem)
     (; boundary_model) = particle_system
 

--- a/src/schemes/boundary/system.jl
+++ b/src/schemes/boundary/system.jl
@@ -138,11 +138,7 @@ end
     return 0
 end
 
-@inline function n_moving_particles(system::BoundarySPHSystem{
-                                                              <:BoundaryModelDummyParticles{
-                                                                                            ContinuityDensity
-                                                                                            }
-                                                              })
+@inline function n_moving_particles(system::BoundarySPHSystem{<:BoundaryModelDummyParticles{ContinuityDensity}})
     return nparticles(system)
 end
 
@@ -238,10 +234,7 @@ function write_v0!(v0, system::BoundarySPHSystem)
 end
 
 function write_v0!(v0,
-                   system::BoundarySPHSystem{
-                                             <:BoundaryModelDummyParticles{ContinuityDensity
-                                                                           }
-                                             })
+                   system::BoundarySPHSystem{<:BoundaryModelDummyParticles{ContinuityDensity}})
     (; cache) = system.boundary_model
     (; initial_density) = cache
 
@@ -257,10 +250,7 @@ function restart_with!(system::BoundarySPHSystem, v, u)
     return system
 end
 
-function restart_with!(system::BoundarySPHSystem{
-                                                 <:BoundaryModelDummyParticles{
-                                                                               ContinuityDensity
-                                                                               }},
+function restart_with!(system::BoundarySPHSystem{<:BoundaryModelDummyParticles{ContinuityDensity}},
                        v, u)
     (; initial_density) = model.cache
 

--- a/src/schemes/fluid/entropically_damped_sph/system.jl
+++ b/src/schemes/fluid/entropically_damped_sph/system.jl
@@ -71,11 +71,13 @@ struct EntropicallyDampedSPHSystem{NDIMS, ELTYPE <: Real, DC, K, V, PF} <:
 
         density_calculator = SummationDensity()
 
-        new{NDIMS, ELTYPE, typeof(density_calculator), typeof(smoothing_kernel),
-            typeof(viscosity), typeof(initial_pressure_function)
-            }(initial_condition, mass, density, density_calculator, smoothing_kernel,
-              smoothing_length, sound_speed, viscosity, nu_edac, initial_pressure_function,
-              acceleration_)
+        new{NDIMS, ELTYPE, typeof(density_calculator),
+            typeof(smoothing_kernel), typeof(viscosity),
+            typeof(initial_pressure_function)}(initial_condition, mass, density,
+                                               density_calculator, smoothing_kernel,
+                                               smoothing_length, sound_speed, viscosity,
+                                               nu_edac, initial_pressure_function,
+                                               acceleration_)
     end
 end
 

--- a/src/schemes/fluid/weakly_compressible_sph/system.jl
+++ b/src/schemes/fluid/weakly_compressible_sph/system.jl
@@ -76,11 +76,11 @@ struct WeaklyCompressibleSPHSystem{NDIMS, ELTYPE <: Real, DC, SE, K, V, DD, COR,
 
         return new{NDIMS, ELTYPE, typeof(density_calculator), typeof(state_equation),
                    typeof(smoothing_kernel), typeof(viscosity), typeof(density_diffusion),
-                   typeof(correction), typeof(cache)
-                   }(initial_condition, mass, pressure,
-                     density_calculator, state_equation,
-                     smoothing_kernel, smoothing_length, acceleration_, viscosity,
-                     density_diffusion, correction, cache)
+                   typeof(correction), typeof(cache)}(initial_condition, mass, pressure,
+                                                      density_calculator, state_equation,
+                                                      smoothing_kernel, smoothing_length,
+                                                      acceleration_, viscosity,
+                                                      density_diffusion, correction, cache)
     end
 end
 

--- a/src/schemes/solid/total_lagrangian_sph/rhs.jl
+++ b/src/schemes/solid/total_lagrangian_sph/rhs.jl
@@ -131,9 +131,7 @@ end
 
 @inline function continuity_equation!(dv, v_particle_system, v_neighbor_system,
                                       particle, neighbor, pos_diff, distance,
-                                      particle_system::TotalLagrangianSPHSystem{
-                                                                                <:BoundaryModelDummyParticles
-                                                                                },
+                                      particle_system::TotalLagrangianSPHSystem{<:BoundaryModelDummyParticles},
                                       neighbor_system::WeaklyCompressibleSPHSystem)
     (; density_calculator) = particle_system.boundary_model
 

--- a/src/schemes/solid/total_lagrangian_sph/system.jl
+++ b/src/schemes/solid/total_lagrangian_sph/system.jl
@@ -184,11 +184,7 @@ timer_name(::TotalLagrangianSPHSystem) = "solid"
     return ndims(system)
 end
 
-@inline function v_nvariables(system::TotalLagrangianSPHSystem{
-                                                               <:BoundaryModelDummyParticles{
-                                                                                             ContinuityDensity
-                                                                                             }
-                                                               })
+@inline function v_nvariables(system::TotalLagrangianSPHSystem{<:BoundaryModelDummyParticles{ContinuityDensity}})
     return ndims(system) + 1
 end
 


### PR DESCRIPTION
Applying the new changes in https://github.com/domluna/JuliaFormatter.jl/pull/785.
This also resolves the ugly line breaks introduced in #300.

This PR has high priority because CI will fail on main with the new JuliaFormatter release.