### PR TITLE
Rotate rectangular shape and tank

### DIFF
--- a/examples/fluid/rectangular_tank_2d.jl
+++ b/examples/fluid/rectangular_tank_2d.jl
@@ -29,7 +29,7 @@ state_equation = StateEquationCole(sound_speed, 7, fluid_density, atmospheric_pr
 
 tank = RectangularTank(fluid_particle_spacing, initial_fluid_size, tank_size, fluid_density,
                        n_layers=boundary_layers, spacing_ratio=spacing_ratio,
-                       acceleration=(0.0, -gravity), state_equation=state_equation)
+                       acceleration=(0.0, -gravity), state_equation=state_equation, rot_angle=π/6)
 
 # ==========================================================================================
 # ==== Fluid

--- a/examples/fluid/rectangular_tank_2d.jl
+++ b/examples/fluid/rectangular_tank_2d.jl
@@ -29,7 +29,7 @@ state_equation = StateEquationCole(sound_speed, 7, fluid_density, atmospheric_pr
 
 tank = RectangularTank(fluid_particle_spacing, initial_fluid_size, tank_size, fluid_density,
                        n_layers=boundary_layers, spacing_ratio=spacing_ratio,
-                       acceleration=(0.0, -gravity), state_equation=state_equation, rot_angle=π/6)
+                       acceleration=(0.0, -gravity), state_equation=state_equation)
 
 # ==========================================================================================
 # ==== Fluid

--- a/src/setups/rectangular_tank.jl
+++ b/src/setups/rectangular_tank.jl
@@ -1,6 +1,6 @@
 @doc raw"""
     RectangularTank(particle_spacing, fluid_size, tank_size, fluid_density;
-                    n_layers=1, spacing_ratio=1.0,
+                    n_layers=1, spacing_ratio=1.0, min_coordinates=zeros(length(fluid_size))
                     init_velocity=zeros(length(fluid_size)),
                     boundary_density=fluid_density,
                     faces=Tuple(trues(2 * length(fluid_size))))
@@ -18,6 +18,7 @@ Rectangular tank filled with a fluid to set up dam-break-style simulations.
 - `spacing_ratio`:      Ratio of `particle_spacing` to boundary particle spacing.
                         A value of 2 means that the boundary particle spacing will be
                         half the fluid particle spacing.
+- `min_coordinates`:    Coordinates of the corner in negative coordinate directions.
 - `init_velocity`:      The initial velocity of each fluid particle as `(x, y)` (or `(x, y, z)` in 3D).
 - `boundary_density`:   Density of each boundary particle (by default set to the rest density)
 - `faces`:              By default all faces are generated. Set faces by passing a
@@ -58,6 +59,7 @@ struct RectangularTank{NDIMS, NDIMSt2, ELTYPE <: Real}
 
     function RectangularTank(particle_spacing, fluid_size, tank_size, fluid_density;
                              pressure=0.0, n_layers=1, spacing_ratio=1.0,
+                             min_coordinates=zeros(length(fluid_size)),
                              init_velocity=zeros(length(fluid_size)),
                              boundary_density=fluid_density,
                              faces=Tuple(trues(2 * length(fluid_size))),
@@ -118,6 +120,10 @@ struct RectangularTank{NDIMS, NDIMSt2, ELTYPE <: Real}
         boundary = InitialCondition(boundary_coordinates, boundary_velocities,
                                     boundary_masses, boundary_densities,
                                     particle_spacing=boundary_spacing)
+
+        # Move the tank corner in the negative coordinate directions to the desired position.
+        fluid.coordinates .+= min_coordinates
+        boundary.coordinates .+= min_coordinates
 
         return new{NDIMS, 2 * NDIMS, ELTYPE}(fluid, boundary, fluid_size_, tank_size_,
                                              faces, face_indices,

--- a/src/util.jl
+++ b/src/util.jl
@@ -317,3 +317,7 @@ end
 function type2string(type)
     return string(nameof(typeof(type)))
 end
+
+rot_matrix(θ, NDIMS::Val{1}) = sign(θ) == π ? -1 : 1
+rot_matrix(θ, NDIMS::Val{2}) = SMatrix{2, 2}(cos(θ), -sin(θ), sin(θ), cos(θ))
+rot_matrix(θ, NDIMS::Val{3}) = SMatrix{3, 3}(cos(θ), -sin(θ), 0, sin(θ), cos(θ), 0, 0, 0, 1)

--- a/src/util.jl
+++ b/src/util.jl
@@ -318,6 +318,6 @@ function type2string(type)
     return string(nameof(typeof(type)))
 end
 
-rot_matrix(θ, NDIMS::Val{1}) = sign(θ) == π ? -1 : 1
-rot_matrix(θ, NDIMS::Val{2}) = SMatrix{2, 2}(cos(θ), -sin(θ), sin(θ), cos(θ))
-rot_matrix(θ, NDIMS::Val{3}) = SMatrix{3, 3}(cos(θ), -sin(θ), 0, sin(θ), cos(θ), 0, 0, 0, 1)
+rot_matrix(θ, NDIMS::Val{1}) = θ == π ? -1 : 1
+rot_matrix(θ, NDIMS::Val{2}) = SMatrix{2, 2}([cos(θ) -sin(θ); sin(θ) cos(θ)])
+rot_matrix(θ, NDIMS::Val{3}) = SMatrix{3, 3}([cos(θ) -sin(θ) 0; sin(θ) cos(θ) 0; 0 0 1])

--- a/test/setups/rectangular_tank.jl
+++ b/test/setups/rectangular_tank.jl
@@ -10,6 +10,7 @@
         @testset "Coordinates" begin
             particle_spacings = [0.1, 0.2]
             spacing_ratios = [1, 3]
+            min_coordinates = [(0.0, 0.0), (-0.3, 2.0)]
 
             expected_fluid_coords = [
                 [0.05 0.15 0.25 0.35 0.45 0.05 0.15 0.25 0.35 0.45 0.05 0.15 0.25 0.35 0.45 0.05 0.15 0.25 0.35 0.45;
@@ -33,17 +34,22 @@
                 ],
             ]
 
-            @testset "Particle Spacing: $(particle_spacings[i])" for i in eachindex(particle_spacings)
-                @testset "Spacing Ratio: $(spacing_ratios[j])" for j in eachindex(spacing_ratios)
-                    tank = RectangularTank(particle_spacings[i],
-                                           (water_width, water_height),
-                                           (tank_width, tank_height),
-                                           water_density,
-                                           spacing_ratio=spacing_ratios[j])
-
-                    @test isapprox(tank.fluid.coordinates, expected_fluid_coords[i])
-                    @test isapprox(tank.boundary.coordinates,
-                                   expected_bound_coords[i][j])
+            @testset "Move Tank: $(min_coordinates[i])" for i in eachindex(min_coordinates)
+                @testset "Particle Spacing: $(particle_spacings[j])" for j in eachindex(particle_spacings)
+                    @testset "Spacing Ratio: $(spacing_ratios[k])" for k in eachindex(spacing_ratios)
+                        tank = RectangularTank(particle_spacings[j],
+                                               (water_width, water_height),
+                                               (tank_width, tank_height),
+                                               water_density,
+                                               spacing_ratio=spacing_ratios[k],
+                                               min_coordinates=min_coordinates[i])
+                        expected_fluid_coords_ = copy(expected_fluid_coords[j])
+                        expected_bound_coords_ = copy(expected_bound_coords[j][k])
+                        expected_fluid_coords_ .+= min_coordinates[i]
+                        expected_bound_coords_ .+= min_coordinates[i]
+                        @test isapprox(tank.fluid.coordinates, expected_fluid_coords_)
+                        @test isapprox(tank.boundary.coordinates, expected_bound_coords_)
+                    end
                 end
             end
         end
@@ -267,6 +273,7 @@ end
         @testset "Coordinates" begin
             particle_spacings = [0.1, 0.2]
             spacing_ratios = [1, 3]
+            min_coordinates = [(0.0, 0.0, 0.0), (-0.3, 2.0, -0.5)]
 
             expected_fluid_coords = [
                 [0.05 0.15 0.25 0.35 0.05 0.15 0.25 0.35 0.05 0.15 0.25 0.35 0.05 0.15 0.25 0.35 0.05 0.15 0.25 0.35 0.05 0.15 0.25 0.35 0.05 0.15 0.25 0.35 0.05 0.15 0.25 0.35 0.05 0.15 0.25 0.35 0.05 0.15 0.25 0.35 0.05 0.15 0.25 0.35 0.05 0.15 0.25 0.35 0.05 0.15 0.25 0.35 0.05 0.15 0.25 0.35 0.05 0.15 0.25 0.35 0.05 0.15 0.25 0.35;
@@ -296,17 +303,23 @@ end
                 ],
             ]
 
-            @testset "Particle Spacing: $(particle_spacings[i])" for i in eachindex(particle_spacings)
-                @testset "Spacing Ratio: $(spacing_ratios[j])" for j in eachindex(spacing_ratios)
-                    tank = RectangularTank(particle_spacings[i],
-                                           (water_width, water_height, water_depth),
-                                           (tank_width, tank_height, tank_depth),
-                                           water_density,
-                                           spacing_ratio=spacing_ratios[j])
+            @testset "Move Tank: $(min_coordinates[i])" for i in eachindex(min_coordinates)
+                @testset "Particle Spacing: $(particle_spacings[j])" for j in eachindex(particle_spacings)
+                    @testset "Spacing Ratio: $(spacing_ratios[k])" for k in eachindex(spacing_ratios)
+                        tank = RectangularTank(particle_spacings[j],
+                                               (water_width, water_height, water_depth),
+                                               (tank_width, tank_height, tank_depth),
+                                               water_density,
+                                               spacing_ratio=spacing_ratios[k],
+                                               min_coordinates=min_coordinates[i])
+                        expected_fluid_coords_ = copy(expected_fluid_coords[j])
+                        expected_bound_coords_ = copy(expected_bound_coords[j][k])
+                        expected_fluid_coords_ .+= min_coordinates[i]
+                        expected_bound_coords_ .+= min_coordinates[i]
 
-                    @test isapprox(tank.fluid.coordinates, expected_fluid_coords[i])
-                    @test isapprox(tank.boundary.coordinates,
-                                   expected_bound_coords[i][j])
+                        @test isapprox(tank.fluid.coordinates, expected_fluid_coords_)
+                        @test isapprox(tank.boundary.coordinates, expected_bound_coords_)
+                    end
                 end
             end
         end


### PR DESCRIPTION
The problem is that I can't rotate the `acceleration` since we have this barrier
```julia
        throw(ArgumentError("hydrostatic pressure calculation is not supported with " *
                            "diagonal acceleration"))
```
therefor the IC looks like this:
![image](https://github.com/trixi-framework/TrixiParticles.jl/assets/73897120/5ebe49f1-d1c1-43d7-9fab-be5d1285047c)

@efaulhaber what do you think? is it easy to implement a support also for diagonal acceleration? Then I only have to add this line:
```julia
acceleration = rot_matrix(rot_angle, Val(NDIMS)) * acceleration
```
