### PR TITLE
Add missing compat entries for test

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -12,6 +12,9 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+CSV = "0.10"
+DataFrames = "1.6"
+JSON = "0.21"
 OrdinaryDiffEq = "6.49"
 Plots = "1"
 Polyester = "0.7"


### PR DESCRIPTION
To avoid wasting resources with 3 separate CI runs.

Closes #385, #386, #387.