### PR TITLE
Fix plane interpolation example

### DIFF
--- a/examples/postprocessing/interpolation_plane.jl
+++ b/examples/postprocessing/interpolation_plane.jl
@@ -19,9 +19,9 @@ original_plane = interpolate_plane_2d(interpolation_start, interpolation_end, re
                                       semi, fluid_system, sol)
 original_x = [point[1] for point in original_plane.coord]
 original_y = [point[2] for point in original_plane.coord]
-original_density = original_plane.density
+original_pressure = original_plane.pressure
 
-# Plane with double smoothing length
+# Plane with double smoothing length.
 # Utilizing a higher `smoothing_length` in SPH interpolation increases the amount of smoothing,
 # thereby reducing the visibility of disturbances. It also increases the distance
 # from free surfaces where the fluid is cut off. This adjustment in `smoothing_length`
@@ -31,37 +31,36 @@ double_smoothing_plane = interpolate_plane_2d(interpolation_start, interpolation
                                               smoothing_length=2.0 * smoothing_length)
 double_x = [point[1] for point in double_smoothing_plane.coord]
 double_y = [point[2] for point in double_smoothing_plane.coord]
-double_density = double_smoothing_plane.density
+double_pressure = double_smoothing_plane.pressure
 
-# Plane with half smoothing length
+# Plane with half smoothing length.
 # Employing a lower `smoothing_length` in SPH interpolation reduces the amount of smoothing,
 # consequently increasing the visibility of disturbances. Simultaneously, it allows for a more
 # precise cutoff of the fluid at free surfaces. This change in `smoothing_length` can impact the
 # balance between the detail of disturbances captured and the precision of fluid representation near surfaces.
 half_smoothing_plane = interpolate_plane_2d(interpolation_start, interpolation_end,
-                                            resolution,
-                                            semi, fluid_system, sol,
+                                            resolution, semi, fluid_system, sol,
                                             smoothing_length=0.5 * smoothing_length)
 half_x = [point[1] for point in half_smoothing_plane.coord]
 half_y = [point[2] for point in half_smoothing_plane.coord]
-half_density = half_smoothing_plane.density
+half_pressure = half_smoothing_plane.pressure
 
-scatter1 = scatter(original_x, original_y, zcolor=original_density, marker=:circle,
+scatter1 = scatter(original_x, original_y, zcolor=original_pressure, marker=:circle,
                    markersize=2, markercolor=:viridis, markerstrokewidth=0)
-scatter2 = scatter(double_x, double_y, zcolor=double_density, marker=:circle, markersize=2,
+scatter2 = scatter(double_x, double_y, zcolor=double_pressure, marker=:circle, markersize=2,
                    markercolor=:viridis, markerstrokewidth=0)
-scatter3 = scatter(half_x, half_y, zcolor=half_density, marker=:circle, markersize=2,
+scatter3 = scatter(half_x, half_y, zcolor=half_pressure, marker=:circle, markersize=2,
                    markercolor=:viridis, markerstrokewidth=0)
 
 plot1 = plot(scatter1, xlabel="X Coordinate", ylabel="Y Coordinate",
-             title="Density Distribution", colorbar_title="Density", ylim=(0.0, 1.0),
-             legend=false, clim=(1000, 1010), colorbar=true)
+             title="Pressure Distribution", colorbar_title="Pressure", ylim=(0.0, 1.0),
+             legend=false, clim=(0, 9000), colorbar=true)
 plot2 = plot(scatter2, xlabel="X Coordinate", ylabel="Y Coordinate",
-             title="Density with 2x Smoothing Length", colorbar_title="Density",
-             ylim=(0.0, 1.0), legend=false, clim=(1000, 1010), colorbar=true)
+             title="Pressure with 2x Smoothing Length", colorbar_title="Pressure",
+             ylim=(0.0, 1.0), legend=false, clim=(0, 9000), colorbar=true)
 plot3 = plot(scatter3, xlabel="X Coordinate", ylabel="Y Coordinate",
-             title="Density with 0.5x Smoothing Length", colorbar_title="Density",
-             ylim=(0.0, 1.0), legend=false, clim=(1000, 1010), colorbar=true)
+             title="Pressure with 0.5x Smoothing Length", colorbar_title="Pressure",
+             ylim=(0.0, 1.0), legend=false, clim=(0, 9000), colorbar=true)
 
 trixi_include(@__MODULE__,
               joinpath(examples_dir(), "fluid", "hydrostatic_water_column_3d.jl"),
@@ -80,14 +79,14 @@ original_plane = interpolate_plane_3d(p1, p2, p3, resolution, semi,
 original_x = [point[1] for point in original_plane.coord]
 original_y = [point[2] for point in original_plane.coord]
 original_z = [point[3] for point in original_plane.coord]
-original_density = original_plane.density
+original_pressure = original_plane.pressure
 
-scatter_3d = scatter3d(original_x, original_y, original_z, marker_z=original_density,
+scatter_3d = scatter3d(original_x, original_y, original_z, marker_z=original_pressure,
                        color=:viridis, markerstrokewidth=0)
 
 plot_3d = plot(scatter_3d, xlabel="X", ylabel="Y", zlabel="Z",
-               title="3D Scatter Plot with Density Coloring", legend=false,
-               clim=(1000, 1010), colorbar=false)
+               title="3D Scatter Plot with Pressure Coloring", legend=false,
+               clim=(0, 9000), colorbar=false)
 
 combined_plot = plot(plot1, plot2, plot3, plot_3d, layout=(2, 2),
                      size=(1000, 1500), margin=3mm)


### PR DESCRIPTION
The density distribution changed when we replaced the state equation in the example. Now the limits of the colorbar are off:
![grafik](https://github.com/trixi-framework/TrixiParticles.jl/assets/44124897/da503810-6f13-4844-871a-fa3768f84037)
I changed the example to plot pressure instead, whose scale doesn't change with parameters like state equation and speed of sound:
![grafik](https://github.com/trixi-framework/TrixiParticles.jl/assets/44124897/8057764d-3c7a-4a17-833b-68a9ac49c29a)
