### PR TITLE
Fix initialization of `SolutionSavingCallback`

### DIFF
--- a/src/callbacks/solution_saving.jl
+++ b/src/callbacks/solution_saving.jl
@@ -62,7 +62,7 @@ saving_callback = SolutionSavingCallback(dt=0.1, my_custom_quantity=kinetic_ener
 └──────────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 """
-struct SolutionSavingCallback{I, CQ}
+mutable struct SolutionSavingCallback{I, CQ}
     interval              :: I
     save_initial_solution :: Bool
     save_final_solution   :: Bool
@@ -72,7 +72,7 @@ struct SolutionSavingCallback{I, CQ}
     prefix                :: String
     max_coordinates       :: Float64
     custom_quantities     :: CQ
-    latest_saved_iter     :: Vector{Int}
+    latest_saved_iter     :: Int
 end
 
 function SolutionSavingCallback(; interval::Integer=0, dt=0.0,
@@ -97,7 +97,7 @@ function SolutionSavingCallback(; interval::Integer=0, dt=0.0,
                                                save_initial_solution, save_final_solution,
                                                write_meta_data, verbose, output_directory,
                                                prefix, max_coordinates, custom_quantities,
-                                               [-1])
+                                               -1)
 
     if dt > 0
         # Add a `tstop` every `dt`, and save the final solution.
@@ -121,6 +121,9 @@ function initialize_save_cb!(cb, u, t, integrator)
 end
 
 function initialize_save_cb!(solution_callback::SolutionSavingCallback, u, t, integrator)
+    # Reset `latest_saved_iter`
+    solution_callback.latest_saved_iter = -1
+
     # Save initial solution
     if solution_callback.save_initial_solution
         # Update systems to compute quantities like density and pressure.
@@ -152,7 +155,7 @@ function (solution_callback::SolutionSavingCallback)(integrator)
     semi = integrator.p
     iter = get_iter(interval, integrator)
 
-    if iter == latest_saved_iter[1]
+    if iter == latest_saved_iter
         # This should only happen at the end of the simulation when using `dt` and the
         # final time is not a multiple of the saving interval.
         @assert isfinished(integrator)
@@ -161,7 +164,7 @@ function (solution_callback::SolutionSavingCallback)(integrator)
         iter += 1
     end
 
-    latest_saved_iter[1] = iter
+    latest_saved_iter = iter
 
     if verbose
         println("Writing solution to $output_directory at t = $(integrator.t)")


### PR DESCRIPTION
Without the reset of `latest_saved_iter`, the `SolutionSavingCallback` can't be reused for a second simulation. Defining the callback in the REPL and passing it to `trixi_include` fails on main when running a second simulation with the same callback.