### PR TITLE
Add missing semicolon for kwarg

### DIFF
--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -14,7 +14,7 @@ end
            integrator.iter == integrator.opts.maxiters
 end
 
-@inline function condition_integrator_interval(integrator, interval,
+@inline function condition_integrator_interval(integrator, interval;
                                                save_final_solution=true)
     # With error-based step size control, some steps can be rejected. Thus,
     #   `integrator.iter >= integrator.stats.naccept`


### PR DESCRIPTION
`DiscreteCallback` isn't working otherwise 