### PR TITLE
TrixiParticles on GPUs with CUDA.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,9 @@ authors = ["erik.faulhaber <44124897+efaulhaber@users.noreply.github.com>"]
 version = "0.1.0"
 
 [deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"

--- a/src/TrixiParticles.jl
+++ b/src/TrixiParticles.jl
@@ -3,6 +3,8 @@ module TrixiParticles
 using Reexport: @reexport
 
 using CSV: CSV
+using CUDA: CUDA, CuArray, CuVector
+using Adapt
 using Dates
 using DataFrames: DataFrame
 using DiffEqCallbacks: PeriodicCallback, PeriodicCallbackAffect, PresetTimeCallback

--- a/src/general/density_calculators.jl
+++ b/src/general/density_calculators.jl
@@ -27,12 +27,20 @@ struct ContinuityDensity end
     particle_density(v, system.density_calculator, system, particle)
 end
 
+@inline function current_density(v, system)
+    current_density(v, system.density_calculator, system)
+end
+
 @inline function particle_density(v, ::SummationDensity, system, particle)
     return system.cache.density[particle]
 end
 
 @inline function particle_density(v, ::ContinuityDensity, system, particle)
     return v[end, particle]
+end
+
+@inline function current_density(v, ::ContinuityDensity, system)
+    return view(v, size(v, 1), :)
 end
 
 function summation_density!(system, semi, u, u_ode, density;

--- a/src/general/system.jl
+++ b/src/general/system.jl
@@ -57,7 +57,8 @@ end
 # This can be dispatched by system type.
 @inline initial_coordinates(system) = system.initial_condition.coordinates
 
-@inline current_velocity(v, system, particle) = extract_svector(v, system, particle)
+@inline current_velocity(v, system, particle) = extract_svector(v, system, particle)    
+@inline current_velocity(v, system) = view(v, 1:ndims(system), :)
 
 @inline function current_acceleration(system, particle)
     # TODO: Return `dv` of solid particles

--- a/src/neighborhood_search/neighborhood_search.jl
+++ b/src/neighborhood_search/neighborhood_search.jl
@@ -27,6 +27,18 @@ end
                           Val(parallel))
 end
 
+@inline function for_particle_neighbor(f, system_coords::CuArray, neighbor_coords,
+                                       neighborhood_search;
+                                       particles=axes(system_coords, 2), parallel=true)
+    CUDA.@cuda threads=size(system_coords, 2) for_particle_neighbor_kernel(f, system_coords, neighbor_coords, neighborhood_search)
+end
+
+@inline function for_particle_neighbor_kernel(f, system_coords, neighbor_coords, neighborhood_search)
+    for_particle_neighbor_inner(f, system_coords, neighbor_coords, neighborhood_search, CUDA.threadIdx().x)
+
+    return nothing
+end
+
 @inline function for_particle_neighbor(f, system_coords, neighbor_coords,
                                        neighborhood_search, particles, parallel::Val{true})
     @threaded for particle in particles

--- a/src/schemes/boundary/dummy_particles/dummy_particles.jl
+++ b/src/schemes/boundary/dummy_particles/dummy_particles.jl
@@ -37,9 +37,9 @@ boundary_model = BoundaryModelDummyParticles(densities, masses, AdamiPressureExt
 BoundaryModelDummyParticles(AdamiPressureExtrapolation, ViscosityAdami)
 ```
 """
-struct BoundaryModelDummyParticles{DC, ELTYPE <: Real, SE, K, V, COR, C}
-    pressure           :: Vector{ELTYPE}
-    hydrodynamic_mass  :: Vector{ELTYPE}
+struct BoundaryModelDummyParticles{DC, ELTYPE <: Real, SE, K, V, COR, C, A}
+    pressure           :: A
+    hydrodynamic_mass  :: A
     state_equation     :: SE
     density_calculator :: DC
     smoothing_kernel   :: K
@@ -47,8 +47,9 @@ struct BoundaryModelDummyParticles{DC, ELTYPE <: Real, SE, K, V, COR, C}
     viscosity          :: V
     correction         :: COR
     cache              :: C
+end
 
-    function BoundaryModelDummyParticles(initial_density, hydrodynamic_mass,
+function BoundaryModelDummyParticles(initial_density, hydrodynamic_mass,
                                          density_calculator, smoothing_kernel,
                                          smoothing_length; viscosity=nothing,
                                          state_equation=nothing, correction=nothing)
@@ -64,14 +65,13 @@ struct BoundaryModelDummyParticles{DC, ELTYPE <: Real, SE, K, V, COR, C}
                  create_cache_model(correction, initial_density, NDIMS,
                                     n_particles)..., cache...)
 
-        new{typeof(density_calculator), eltype(initial_density),
+        BoundaryModelDummyParticles{typeof(density_calculator), eltype(initial_density),
             typeof(state_equation), typeof(smoothing_kernel), typeof(viscosity),
-            typeof(correction), typeof(cache)}(pressure, hydrodynamic_mass, state_equation,
+            typeof(correction), typeof(cache), typeof(pressure)}(pressure, hydrodynamic_mass, state_equation,
                                                density_calculator,
                                                smoothing_kernel, smoothing_length,
                                                viscosity, correction, cache)
     end
-end
 
 @doc raw"""
     AdamiPressureExtrapolation()

--- a/src/schemes/fluid/fluid.jl
+++ b/src/schemes/fluid/fluid.jl
@@ -17,18 +17,26 @@ function write_u0!(u0, system::FluidSystem)
     for particle in eachparticle(system)
         # Write particle coordinates
         for dim in 1:ndims(system)
-            u0[dim, particle] = initial_condition.coordinates[dim, particle]
+            CUDA.@allowscalar u0[dim, particle] = initial_condition.coordinates[dim, particle]
         end
     end
 
     return u0
 end
 
+# function write_u0!(u0::CuArray, system::FluidSystem)
+#     (; initial_condition) = system
+
+#     copyto!(u0, initial_condition.coordinates)
+
+#     return u0
+# end
+
 function write_v0!(v0, system::FluidSystem)
     for particle in eachparticle(system)
         # Write particle velocities
         for dim in 1:ndims(system)
-            v0[dim, particle] = system.initial_condition.velocity[dim, particle]
+            CUDA.@allowscalar v0[dim, particle] = system.initial_condition.velocity[dim, particle]
         end
     end
 
@@ -36,6 +44,14 @@ function write_v0!(v0, system::FluidSystem)
 
     return v0
 end
+
+# function write_v0!(v0::CuArray, system::FluidSystem)
+#     copyto!(v0, system.initial_condition.velocity)
+
+#     write_v0!(v0, system, system.density_calculator)
+
+#     return v0
+# end
 
 write_v0!(v0, system, density_calculator) = v0
 

--- a/src/visualization/write2vtk.jl
+++ b/src/visualization/write2vtk.jl
@@ -56,7 +56,7 @@ function trixi2vtk(vu_ode, semi, t; iter=nothing, output_directory="out", prefix
         u = wrap_u(u_ode, system, semi)
         periodic_box = get_neighborhood_search(system, semi).periodic_box
 
-        trixi2vtk(v, u, t, system, periodic_box;
+        CUDA.@allowscalar trixi2vtk(v, u, t, system, periodic_box;
                   output_directory=output_directory,
                   system_name=filenames[system_index], iter=iter, prefix=prefix,
                   write_meta_data=write_meta_data, max_coordinates=max_coordinates,


### PR DESCRIPTION
I spent the last two days building a first prototype for TrixiParticles.jl with CUDA.jl.

The good news:
- It works! I can run the oscillating drop simulation successfully on an RTX 3090.

The bad news:
- It doesn't work with boundary systems yet.
- It's about 30x slower than on the CPU.