### PR TITLE
Change NHS API to update with both systems' coordinates

### DIFF
--- a/src/general/interpolation.jl
+++ b/src/general/interpolation.jl
@@ -485,7 +485,7 @@ end
 function process_neighborhood_searches(semi, u_ode, ref_system, smoothing_length)
     if isapprox(smoothing_length, ref_system.smoothing_length)
         # Update existing NHS
-        update_nhs(u_ode, semi)
+        update_nhs!(semi, u_ode)
         neighborhood_searches = semi.neighborhood_searches[system_indices(ref_system, semi)]
     else
         ref_smoothing_kernel = ref_system.smoothing_kernel

--- a/src/general/semidiscretization.jl
+++ b/src/general/semidiscretization.jl
@@ -140,7 +140,7 @@ function create_neighborhood_search(system, neighbor, ::Val{GridNeighborhoodSear
                                                    periodic_box_max_corner=periodic_box_max_corner,
                                                    threaded_nhs_update=threaded_nhs_update)
     # Initialize neighborhood search
-    initialize!(search, initial_coordinates(neighbor))
+    initialize!(search, initial_coordinates(system), initial_coordinates(neighbor))
 
     return search
 end

--- a/src/general/semidiscretization.jl
+++ b/src/general/semidiscretization.jl
@@ -611,24 +611,26 @@ function update_nhs!(neighborhood_search,
                      system::FluidSystem,
                      neighbor::Union{FluidSystem, TotalLagrangianSPHSystem},
                      u_system, u_neighbor)
-    update!(neighborhood_search, current_coordinates(u_neighbor, neighbor))
+    update!(neighborhood_search,
+            current_coordinates(u_system, system),
+            current_coordinates(u_neighbor, neighbor), particles_moving=(true, true))
 end
 
 function update_nhs!(neighborhood_search,
                      system::FluidSystem, neighbor::BoundarySPHSystem,
                      u_system, u_neighbor)
-    # Only update when the boundary is moving
-    if neighbor.ismoving[]
-        return update!(neighborhood_search, current_coordinates(u_neighbor, neighbor))
-    end
-
-    return neighborhood_search
+    update!(neighborhood_search,
+            current_coordinates(u_system, system),
+            current_coordinates(u_neighbor, neighbor),
+            particles_moving=(true, neighbor.ismoving[]))
 end
 
 function update_nhs!(neighborhood_search,
                      system::TotalLagrangianSPHSystem, neighbor::FluidSystem,
                      u_system, u_neighbor)
-    update!(neighborhood_search, current_coordinates(u_neighbor, neighbor))
+    update!(neighborhood_search,
+            current_coordinates(u_system, system),
+            current_coordinates(u_neighbor, neighbor), particles_moving=(true, true))
 end
 
 function update_nhs!(neighborhood_search,
@@ -641,12 +643,10 @@ end
 function update_nhs!(neighborhood_search,
                      system::TotalLagrangianSPHSystem, neighbor::BoundarySPHSystem,
                      u_system, u_neighbor)
-    # Only update when the boundary is moving
-    if neighbor.ismoving[]
-        return update!(neighborhood_search, current_coordinates(u_neighbor, neighbor))
-    end
-
-    return neighborhood_search
+    update!(neighborhood_search,
+            current_coordinates(u_system, system),
+            current_coordinates(u_neighbor, neighbor),
+            particles_moving=(true, neighbor.ismoving[]))
 end
 
 function update_nhs!(neighborhood_search,
@@ -667,27 +667,33 @@ function update_nhs!(neighborhood_search,
     # - kernel summation (`SummationDensity`)
     # - continuity equation (`ContinuityDensity`)
     # - pressure extrapolation (`AdamiPressureExtrapolation`)
-    update!(neighborhood_search, current_coordinates(u_neighbor, neighbor))
+    update!(neighborhood_search,
+            current_coordinates(u_system, system),
+            current_coordinates(u_neighbor, neighbor),
+            particles_moving=(system.ismoving[], true))
 end
 
 function update_nhs!(neighborhood_search,
                      system::DEMSystem, neighbor::DEMSystem,
                      u_system, u_neighbor)
-    update!(neighborhood_search, current_coordinates(u_neighbor, neighbor))
+    update!(neighborhood_search,
+            current_coordinates(u_system, system),
+            current_coordinates(u_neighbor, neighbor), particles_moving=(true, true))
 end
 
 function update_nhs!(neighborhood_search,
                      system::DEMSystem, neighbor::BoundaryDEMSystem,
                      u_system, u_neighbor)
-    # Don't update for static boundaries
-    return neighborhood_search
+    update!(neighborhood_search,
+            current_coordinates(u_system, system),
+            current_coordinates(u_neighbor, neighbor), particles_moving=(true, false))
 end
 
 function update_nhs!(neighborhood_search,
                      system::BoundaryDEMSystem,
                      neighbor::Union{DEMSystem, BoundaryDEMSystem},
                      u_system, u_neighbor)
-    # Don't update for static boundaries
+    # Don't update. This NHS is never used.
     return neighborhood_search
 end
 

--- a/src/general/semidiscretization.jl
+++ b/src/general/semidiscretization.jl
@@ -651,7 +651,8 @@ end
 
 function update_nhs!(neighborhood_search,
                      system::BoundarySPHSystem,
-                     neighbor::Union{FluidSystem, TotalLagrangianSPHSystem, BoundarySPHSystem},
+                     neighbor::Union{FluidSystem, TotalLagrangianSPHSystem,
+                                     BoundarySPHSystem},
                      u_system, u_neighbor)
     # Don't update. This NHS is never used.
     return neighborhood_search
@@ -659,7 +660,8 @@ end
 
 function update_nhs!(neighborhood_search,
                      system::BoundarySPHSystem{<:BoundaryModelDummyParticles},
-                     neighbor::Union{FluidSystem, TotalLagrangianSPHSystem, BoundarySPHSystem},
+                     neighbor::Union{FluidSystem, TotalLagrangianSPHSystem,
+                                     BoundarySPHSystem},
                      u_system, u_neighbor)
     # Depending on the density calculator of the boundary model, this NHS is used for
     # - kernel summation (`SummationDensity`)
@@ -688,7 +690,6 @@ function update_nhs!(neighborhood_search,
     # Don't update for static boundaries
     return neighborhood_search
 end
-
 
 function check_configuration(systems)
     foreach_system(systems) do system

--- a/src/general/semidiscretization.jl
+++ b/src/general/semidiscretization.jl
@@ -437,7 +437,7 @@ function update_systems_and_nhs(v_ode, u_ode, semi, t)
     end
 
     # Update NHS
-    @trixi_timeit timer() "update nhs" update_nhs(u_ode, semi)
+    @trixi_timeit timer() "update nhs" update_nhs!(semi, u_ode)
 
     # Second update step.
     # This is used to calculate density and pressure of the fluid systems
@@ -467,14 +467,16 @@ function update_systems_and_nhs(v_ode, u_ode, semi, t)
     end
 end
 
-function update_nhs(u_ode, semi)
+function update_nhs!(semi, u_ode)
     # Update NHS for each pair of systems
     foreach_system(semi) do system
+        u_system = wrap_u(u_ode, system, semi)
+
         foreach_system(semi) do neighbor
             u_neighbor = wrap_u(u_ode, neighbor, semi)
             neighborhood_search = get_neighborhood_search(system, neighbor, semi)
 
-            update!(neighborhood_search, nhs_coords(system, neighbor, u_neighbor))
+            update_nhs!(neighborhood_search, system, neighbor, u_system, u_neighbor)
         end
     end
 end
@@ -605,82 +607,88 @@ end
 
 # NHS updates
 # To prevent hard to spot errors there is not default version
-
-function nhs_coords(system::DEMSystem, neighbor::DEMSystem, u)
-    return current_coordinates(u, neighbor)
+function update_nhs!(neighborhood_search,
+                     system::FluidSystem,
+                     neighbor::Union{FluidSystem, TotalLagrangianSPHSystem},
+                     u_system, u_neighbor)
+    update!(neighborhood_search, current_coordinates(u_neighbor, neighbor))
 end
 
-function nhs_coords(system::BoundaryDEMSystem,
-                    neighbor::Union{BoundaryDEMSystem, DEMSystem}, u)
-    return nothing
-end
-function nhs_coords(system::DEMSystem, neighbor::BoundaryDEMSystem, u)
-    return nothing
-end
-
-function nhs_coords(system::FluidSystem,
-                    neighbor::FluidSystem, u)
-    return current_coordinates(u, neighbor)
-end
-
-function nhs_coords(system::FluidSystem,
-                    neighbor::TotalLagrangianSPHSystem, u)
-    return current_coordinates(u, neighbor)
-end
-
-function nhs_coords(system::FluidSystem,
-                    neighbor::BoundarySPHSystem, u)
+function update_nhs!(neighborhood_search,
+                     system::FluidSystem, neighbor::BoundarySPHSystem,
+                     u_system, u_neighbor)
+    # Only update when the boundary is moving
     if neighbor.ismoving[]
-        return current_coordinates(u, neighbor)
+        return update!(neighborhood_search, current_coordinates(u_neighbor, neighbor))
     end
 
-    # Don't update
-    return nothing
+    return neighborhood_search
 end
 
-function nhs_coords(system::TotalLagrangianSPHSystem,
-                    neighbor::FluidSystem, u)
-    return current_coordinates(u, neighbor)
+function update_nhs!(neighborhood_search,
+                     system::TotalLagrangianSPHSystem, neighbor::FluidSystem,
+                     u_system, u_neighbor)
+    update!(neighborhood_search, current_coordinates(u_neighbor, neighbor))
 end
 
-function nhs_coords(system::TotalLagrangianSPHSystem,
-                    neighbor::TotalLagrangianSPHSystem, u)
-    # Don't update
-    return nothing
+function update_nhs!(neighborhood_search,
+                     system::TotalLagrangianSPHSystem, neighbor::TotalLagrangianSPHSystem,
+                     u_system, u_neighbor)
+    # Don't update. Neighborhood search works on the initial coordinates.
+    return neighborhood_search
 end
 
-function nhs_coords(system::TotalLagrangianSPHSystem,
-                    neighbor::BoundarySPHSystem, u)
+function update_nhs!(neighborhood_search,
+                     system::TotalLagrangianSPHSystem, neighbor::BoundarySPHSystem,
+                     u_system, u_neighbor)
+    # Only update when the boundary is moving
     if neighbor.ismoving[]
-        return current_coordinates(u, neighbor)
+        return update!(neighborhood_search, current_coordinates(u_neighbor, neighbor))
     end
 
-    # Don't update
-    return nothing
+    return neighborhood_search
 end
 
-function nhs_coords(system::BoundarySPHSystem,
-                    neighbor::FluidSystem, u)
-    # Don't update
-    return nothing
+function update_nhs!(neighborhood_search,
+                     system::BoundarySPHSystem,
+                     neighbor::Union{FluidSystem, TotalLagrangianSPHSystem, BoundarySPHSystem},
+                     u_system, u_neighbor)
+    # Don't update. This NHS is never used.
+    return neighborhood_search
 end
 
-function nhs_coords(system::BoundarySPHSystem{<:BoundaryModelDummyParticles},
-                    neighbor::FluidSystem, u)
-    return current_coordinates(u, neighbor)
+function update_nhs!(neighborhood_search,
+                     system::BoundarySPHSystem{<:BoundaryModelDummyParticles},
+                     neighbor::Union{FluidSystem, TotalLagrangianSPHSystem, BoundarySPHSystem},
+                     u_system, u_neighbor)
+    # Depending on the density calculator of the boundary model, this NHS is used for
+    # - kernel summation (`SummationDensity`)
+    # - continuity equation (`ContinuityDensity`)
+    # - pressure extrapolation (`AdamiPressureExtrapolation`)
+    update!(neighborhood_search, current_coordinates(u_neighbor, neighbor))
 end
 
-function nhs_coords(system::BoundarySPHSystem,
-                    neighbor::TotalLagrangianSPHSystem, u)
-    # Don't update
-    return nothing
+function update_nhs!(neighborhood_search,
+                     system::DEMSystem, neighbor::DEMSystem,
+                     u_system, u_neighbor)
+    update!(neighborhood_search, current_coordinates(u_neighbor, neighbor))
 end
 
-function nhs_coords(system::BoundarySPHSystem,
-                    neighbor::BoundarySPHSystem, u)
-    # Don't update
-    return nothing
+function update_nhs!(neighborhood_search,
+                     system::DEMSystem, neighbor::BoundaryDEMSystem,
+                     u_system, u_neighbor)
+    # Don't update for static boundaries
+    return neighborhood_search
 end
+
+function update_nhs!(neighborhood_search,
+                     system::BoundaryDEMSystem,
+                     neighbor::Union{DEMSystem, BoundaryDEMSystem},
+                     u_system, u_neighbor)
+    # Don't update for static boundaries
+    return neighborhood_search
+end
+
 
 function check_configuration(systems)
     foreach_system(systems) do system

--- a/src/neighborhood_search/grid_nhs.jl
+++ b/src/neighborhood_search/grid_nhs.jl
@@ -152,17 +152,17 @@ end
     return size(neighborhood_search.cell_buffer, 1)
 end
 
-function initialize!(neighborhood_search::GridNeighborhoodSearch, ::Nothing)
+function initialize!(neighborhood_search::GridNeighborhoodSearch, ::Nothing, ::Nothing)
     # No particle coordinates function -> don't initialize.
     return neighborhood_search
 end
 
 function initialize!(neighborhood_search::GridNeighborhoodSearch{NDIMS},
-                     x::AbstractArray) where {NDIMS}
-    initialize!(neighborhood_search, i -> extract_svector(x, Val(NDIMS), i))
+                     x::AbstractMatrix, y::AbstractMatrix) where {NDIMS}
+    initialize!(neighborhood_search, i -> extract_svector(y, Val(NDIMS), i))
 end
 
-function initialize!(neighborhood_search::GridNeighborhoodSearch, coords_fun)
+function initialize!(neighborhood_search::GridNeighborhoodSearch, coords_fun1, coords_fun2)
     (; hashtable) = neighborhood_search
 
     empty!(hashtable)
@@ -173,7 +173,7 @@ function initialize!(neighborhood_search::GridNeighborhoodSearch, coords_fun)
 
     for particle in 1:nparticles(neighborhood_search)
         # Get cell index of the particle's cell
-        cell = cell_coords(coords_fun(particle), neighborhood_search)
+        cell = cell_coords(coords_fun2(particle), neighborhood_search)
 
         # Add particle to corresponding cell or create cell if it does not exist
         if haskey(hashtable, cell)

--- a/src/neighborhood_search/trivial_nhs.jl
+++ b/src/neighborhood_search/trivial_nhs.jl
@@ -92,7 +92,7 @@ end
     return NDIMS
 end
 
-@inline initialize!(search::TrivialNeighborhoodSearch, coords_fun) = search
+@inline initialize!(search::TrivialNeighborhoodSearch, coords_fun1, coords_fun2) = search
 
 @inline function update!(search::TrivialNeighborhoodSearch, coords_fun1, coords_fun2;
                          particles_moving=(true, true))

--- a/src/neighborhood_search/trivial_nhs.jl
+++ b/src/neighborhood_search/trivial_nhs.jl
@@ -93,5 +93,10 @@ end
 end
 
 @inline initialize!(search::TrivialNeighborhoodSearch, coords_fun) = search
-@inline update!(search::TrivialNeighborhoodSearch, coords_fun) = search
+
+@inline function update!(search::TrivialNeighborhoodSearch, coords_fun1, coords_fun2;
+                         particles_moving=(true, true))
+    return search
+end
+
 @inline eachneighbor(coords, search::TrivialNeighborhoodSearch) = search.eachparticle


### PR DESCRIPTION
I'd prefer changing the API before moving the NHS to a separate package.
With this PR, I pass both system's coordinates to the NHS, together with the information which of the coordinates are changing and which are static. The NHS can then decide if and what to update.

For example, the grid NHS doesn't need to update for fluid-boundary NHS. A neighborhood search that explicitly computes the neighbor lists will have to update them because the fluid particles are moving.