### PR TITLE
Modify error message

### DIFF
--- a/src/general/semidiscretization.jl
+++ b/src/general/semidiscretization.jl
@@ -739,7 +739,7 @@ function check_configuration(boundary_system::BoundarySPHSystem, systems)
            boundary_model isa BoundaryModelDummyParticles &&
            isnothing(boundary_model.state_equation)
             throw(ArgumentError("`WeaklyCompressibleSPHSystem` cannot be used without " *
-                                "setting a `state_equation` for all boundary systems"))
+                                "setting a `state_equation` for all boundary models"))
         end
     end
 end

--- a/test/general/semidiscretization.jl
+++ b/test/general/semidiscretization.jl
@@ -90,7 +90,7 @@
                                                        kernel, 1.0)
 
             error_str = "`WeaklyCompressibleSPHSystem` cannot be used without setting a " *
-                        "`state_equation` for all boundary systems"
+                        "`state_equation` for all boundary models"
             @test_throws ArgumentError(error_str) Semidiscretization(fluid_system,
                                                                      boundary_system)
         end


### PR DESCRIPTION
It might be misleading, because the `BoundarySPHSystem` doesn't have a `state_equation` field.