### PR TITLE
Adapt some code to GPUs

### DIFF
--- a/src/general/system.jl
+++ b/src/general/system.jl
@@ -61,7 +61,7 @@ end
 
 @inline function current_acceleration(system, particle)
     # TODO: Return `dv` of solid particles
-    return SVector(ntuple(_ -> 0.0, Val(ndims(system))))
+    return zero(SVector{ndims(system), eltype(system)})
 end
 
 @inline function smoothing_kernel(system, distance)

--- a/src/schemes/boundary/system.jl
+++ b/src/schemes/boundary/system.jl
@@ -243,6 +243,10 @@ end
 end
 
 @inline function current_velocity(v, system::BoundarySPHSystem, particle)
+    return current_velocity(v, system, system.movement, particle)
+end
+
+@inline function current_velocity(v, system, movement, particle)
     (; cache, ismoving) = system
 
     if ismoving[]
@@ -252,13 +256,25 @@ end
     return SVector(ntuple(_ -> 0.0, Val(ndims(system))))
 end
 
+@inline function current_velocity(v, system, movement::Nothing, particle)
+    return SVector(ntuple(_ -> 0.0, Val(ndims(system))))
+end
+
 @inline function current_acceleration(system::BoundarySPHSystem, particle)
+    return current_acceleration(system, system.movement, particle)
+end
+
+@inline function current_acceleration(system, movement, particle)
     (; cache, ismoving) = system
 
     if ismoving[]
         return extract_svector(cache.acceleration, system, particle)
     end
 
+    return SVector(ntuple(_ -> 0.0, Val(ndims(system))))
+end
+
+@inline function current_acceleration(system, movement::Nothing, particle)
     return SVector(ntuple(_ -> 0.0, Val(ndims(system))))
 end
 

--- a/src/schemes/boundary/system.jl
+++ b/src/schemes/boundary/system.jl
@@ -253,11 +253,11 @@ end
         return extract_svector(cache.velocity, system, particle)
     end
 
-    return SVector(ntuple(_ -> 0.0, Val(ndims(system))))
+    return zero(SVector{ndims(system), eltype(system)})
 end
 
 @inline function current_velocity(v, system, movement::Nothing, particle)
-    return SVector(ntuple(_ -> 0.0, Val(ndims(system))))
+    return zero(SVector{ndims(system), eltype(system)})
 end
 
 @inline function current_acceleration(system::BoundarySPHSystem, particle)
@@ -271,11 +271,11 @@ end
         return extract_svector(cache.acceleration, system, particle)
     end
 
-    return SVector(ntuple(_ -> 0.0, Val(ndims(system))))
+    return zero(SVector{ndims(system), eltype(system)})
 end
 
 @inline function current_acceleration(system, movement::Nothing, particle)
-    return SVector(ntuple(_ -> 0.0, Val(ndims(system))))
+    return zero(SVector{ndims(system), eltype(system)})
 end
 
 @inline function viscous_velocity(v, system::BoundarySPHSystem, particle)

--- a/src/schemes/fluid/fluid.jl
+++ b/src/schemes/fluid/fluid.jl
@@ -14,23 +14,17 @@ end
 function write_u0!(u0, system::FluidSystem)
     (; initial_condition) = system
 
-    for particle in eachparticle(system)
-        # Write particle coordinates
-        for dim in 1:ndims(system)
-            u0[dim, particle] = initial_condition.coordinates[dim, particle]
-        end
-    end
+    # This is as fast as a loop with `@inbounds`, but it's GPU-compatible
+    indices = CartesianIndices(initial_condition.coordinates)
+    copyto!(u0, indices, initial_condition.coordinates, indices)
 
     return u0
 end
 
 function write_v0!(v0, system::FluidSystem)
-    for particle in eachparticle(system)
-        # Write particle velocities
-        for dim in 1:ndims(system)
-            v0[dim, particle] = system.initial_condition.velocity[dim, particle]
-        end
-    end
+    # This is as fast as a loop with `@inbounds`, but it's GPU-compatible
+    indices = CartesianIndices(system.initial_condition.velocity)
+    copyto!(v0, indices, system.initial_condition.velocity, indices)
 
     write_v0!(v0, system, system.density_calculator)
 

--- a/src/schemes/fluid/viscosity.jl
+++ b/src/schemes/fluid/viscosity.jl
@@ -25,7 +25,7 @@ function dv_viscosity(viscosity::Nothing, particle_system, neighbor_system,
                       v_particle_system, v_neighbor_system,
                       particle, neighbor, pos_diff, distance,
                       sound_speed, m_a, m_b, rho_mean)
-    return zero(SVector{ndims(particle_system), eltype(particle_system)})
+    return zero(pos_diff)
 end
 
 @doc raw"""
@@ -100,7 +100,7 @@ end
     pi_ab = viscosity(sound_speed, v_diff, pos_diff, distance, rho_mean, smoothing_length)
 
     if pi_ab < eps()
-        return zero(SVector{ndims(particle_system), eltype(particle_system)})
+        return zero(pos_diff)
     end
 
     return -m_b * pi_ab * smoothing_kernel_grad(particle_system, pos_diff, distance)

--- a/src/schemes/fluid/viscosity.jl
+++ b/src/schemes/fluid/viscosity.jl
@@ -25,7 +25,7 @@ function dv_viscosity(viscosity::Nothing, particle_system, neighbor_system,
                       v_particle_system, v_neighbor_system,
                       particle, neighbor, pos_diff, distance,
                       sound_speed, m_a, m_b, rho_mean)
-    return SVector(ntuple(_ -> 0.0, Val(ndims(particle_system))))
+    return zero(SVector{ndims(particle_system), eltype(particle_system)})
 end
 
 @doc raw"""
@@ -100,7 +100,7 @@ end
     pi_ab = viscosity(sound_speed, v_diff, pos_diff, distance, rho_mean, smoothing_length)
 
     if pi_ab < eps()
-        return SVector(ntuple(_ -> 0.0, Val(ndims(particle_system))))
+        return zero(SVector{ndims(particle_system), eltype(particle_system)})
     end
 
     return -m_b * pi_ab * smoothing_kernel_grad(particle_system, pos_diff, distance)

--- a/src/schemes/fluid/weakly_compressible_sph/system.jl
+++ b/src/schemes/fluid/weakly_compressible_sph/system.jl
@@ -295,10 +295,8 @@ end
 end
 
 function write_v0!(v0, system::WeaklyCompressibleSPHSystem, ::ContinuityDensity)
-    for particle in eachparticle(system)
-        # Set particle densities
-        v0[end, particle] = system.initial_condition.density[particle]
-    end
+    # Note that `.=` is very slightly faster, but not GPU-compatible
+    v0[end, :] = system.initial_condition.density
 
     return v0
 end

--- a/src/schemes/solid/total_lagrangian_sph/system.jl
+++ b/src/schemes/solid/total_lagrangian_sph/system.jl
@@ -181,7 +181,7 @@ end
 
 @inline function current_velocity(v, system::TotalLagrangianSPHSystem, particle)
     if particle > n_moving_particles(system)
-        return SVector(ntuple(_ -> 0.0, Val(ndims(system))))
+        return zero(SVector{ndims(system), eltype(system)})
     end
 
     return extract_svector(v, system, particle)

--- a/src/setups/rectangular_tank.jl
+++ b/src/setups/rectangular_tank.jl
@@ -302,7 +302,7 @@ function initialize_boundaries(particle_spacing, tank_size::NTuple{2},
     face_indices_4 = Array{Int, 2}(undef, n_layers, n_particles_x)
 
     # Create empty array to extend later depending on faces and corners to build
-    boundary_coordinates = Array{Float64, 2}(undef, 2, 0)
+    boundary_coordinates = Array{typeof(particle_spacing), 2}(undef, 2, 0)
 
     # Counts the global index of the particles
     index = 0
@@ -433,7 +433,7 @@ function initialize_boundaries(particle_spacing, tank_size::NTuple{3},
     face_indices_6 = Array{Int, 2}(undef, n_layers, n_particles_x * n_particles_y)
 
     # Create empty array to extend later depending on faces and corners to build
-    boundary_coordinates = Array{Float64, 2}(undef, 3, 0)
+    boundary_coordinates = Array{typeof(particle_spacing), 2}(undef, 3, 0)
 
     # Counts the global index of the particles
     index = 0


### PR DESCRIPTION
Second part of #493.
1. `current_velocity` and `current_acceleration` now statically return zero when `movement` is `nothing` without any dynamic checks.
2. `write_v0!` and `write_u0!` for fluids are now GPU-compatible.
3. Get rid of the hardcoded `Float64` types in the rectangular tank setup.
4. Replace ugly and Float64-hardcoded `SVector(ntuple(_ -> 0.0, Val(ndims(system))))` by a nicer `zero(SVector{ndims(system), eltype(system)})`.