### PR TITLE
Inline viscosity

### DIFF
--- a/src/schemes/fluid/viscosity.jl
+++ b/src/schemes/fluid/viscosity.jl
@@ -1,9 +1,9 @@
 
 # Unpack the neighboring systems viscosity to dispatch on the viscosity type
-function dv_viscosity(particle_system, neighbor_system,
-                      v_particle_system, v_neighbor_system,
-                      particle, neighbor, pos_diff, distance,
-                      sound_speed, m_a, m_b, rho_a, rho_b, grad_kernel)
+@inline function dv_viscosity(particle_system, neighbor_system,
+                              v_particle_system, v_neighbor_system,
+                              particle, neighbor, pos_diff, distance,
+                              sound_speed, m_a, m_b, rho_a, rho_b, grad_kernel)
     viscosity = viscosity_model(particle_system, neighbor_system)
 
     return dv_viscosity(viscosity, particle_system, neighbor_system,
@@ -12,20 +12,20 @@ function dv_viscosity(particle_system, neighbor_system,
                         sound_speed, m_a, m_b, rho_a, rho_b, grad_kernel)
 end
 
-function dv_viscosity(viscosity, particle_system, neighbor_system,
-                      v_particle_system, v_neighbor_system,
-                      particle, neighbor, pos_diff, distance,
-                      sound_speed, m_a, m_b, rho_a, rho_b, grad_kernel)
+@inline function dv_viscosity(viscosity, particle_system, neighbor_system,
+                              v_particle_system, v_neighbor_system,
+                              particle, neighbor, pos_diff, distance,
+                              sound_speed, m_a, m_b, rho_a, rho_b, grad_kernel)
     return viscosity(particle_system, neighbor_system,
                      v_particle_system, v_neighbor_system,
                      particle, neighbor, pos_diff, distance,
                      sound_speed, m_a, m_b, rho_a, rho_b, grad_kernel)
 end
 
-function dv_viscosity(viscosity::Nothing, particle_system, neighbor_system,
-                      v_particle_system, v_neighbor_system,
-                      particle, neighbor, pos_diff, distance,
-                      sound_speed, m_a, m_b, rho_a, rho_b, grad_kernel)
+@inline function dv_viscosity(viscosity::Nothing, particle_system, neighbor_system,
+                              v_particle_system, v_neighbor_system,
+                              particle, neighbor, pos_diff, distance,
+                              sound_speed, m_a, m_b, rho_a, rho_b, grad_kernel)
     return zero(pos_diff)
 end
 


### PR DESCRIPTION
Okay, hear me out. This is a 1.4-1.5x speedup in the fluid-fluid interact, just by inlining `dv_viscosity`. Don't ask me why the difference is so extreme.
<img width="674" alt="grafik" src="https://github.com/user-attachments/assets/0b6c7561-9fec-446f-8e87-650b83ec5590">
