### PR TITLE
Fix `InitialCondition` in 1D

### DIFF
--- a/src/general/initial_condition.jl
+++ b/src/general/initial_condition.jl
@@ -98,8 +98,11 @@ struct InitialCondition{ELTYPE}
                                zeros(ELTYPE, 0), zeros(ELTYPE, 0), zeros(ELTYPE, 0))
         end
 
-        # SVector of coordinates to pass to functions
-        coordinates_svector = reinterpret(reshape, SVector{NDIMS, ELTYPE}, coordinates)
+        # SVector of coordinates to pass to functions.
+        # This will return a vector of SVectors in 2D and 3D, but an 1×n matrix in 1D.
+        coordinates_svector_ = reinterpret(reshape, SVector{NDIMS, ELTYPE}, coordinates)
+        # In 1D, this will reshape the 1×n matrix to a vector, in 2D/3D it will do nothing
+        coordinates_svector = reshape(coordinates_svector_, length(coordinates_svector_))
 
         if velocity isa AbstractMatrix
             velocities = velocity


### PR DESCRIPTION
On `main`:
```
julia> InitialCondition(coordinates=rand(2, 5), density=1000.0, mass=1.0)
InitialCondition{Float64}(-1.0, [0.39780033704153317 0.8731462648953685 … 0.017683248377757255 0.09304512752818128; 0.6458401209021684 0.1505692912566634 … 0.23175472934323182 0.26543618393638657], [0.0 0.0 … 0.0 0.0; 0.0 0.0 … 0.0 0.0], [1.0, 1.0, 1.0, 1.0, 1.0], [1000.0, 1000.0, 1000.0, 1000.0, 1000.0], [0.0, 0.0, 0.0, 0.0, 0.0])

julia> InitialCondition(coordinates=rand(1, 5), density=1000.0, mass=1.0)
ERROR: ArgumentError: `coordinates` and `velocities` must be of the same size
Stacktrace:
 [1] InitialCondition{…}(coordinates::Matrix{…}, velocity::Vector{…}, mass::Float64, density::Float64, pressure::Float64, particle_spacing::Float64)
   @ TrixiParticles ~/git/TrixiParticles.jl/src/general/initial_condition.jl:117
 [2] InitialCondition(; coordinates::Matrix{…}, density::Float64, velocity::Vector{…}, mass::Float64, pressure::Float64, particle_spacing::Float64)
   @ TrixiParticles ~/git/TrixiParticles.jl/src/general/initial_condition.jl:86
 [3] top-level scope
   @ REPL[107]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

This doesn't affect performance in 2D and 3D, as `reshape(v::Vector, length(v))` is literally free. Here is a 3D benchmark on `main`:
```
julia> @btime InitialCondition(coordinates=$(rand(3, 100_000)), density=1000.0, mass=1.0);
  437.833 μs (19 allocations: 6.88 MiB)
```
This PR:
```
julia> @btime InitialCondition(coordinates=$(rand(3, 100_000)), density=1000.0, mass=1.0);
  436.625 μs (19 allocations: 6.88 MiB)
```