### PR TITLE
Skip empty systems

### DIFF
--- a/src/visualization/write2vtk.jl
+++ b/src/visualization/write2vtk.jl
@@ -81,6 +81,11 @@ function trixi2vtk(v_, u_, t, system_, periodic_box; output_directory="out", pre
                    custom_quantities...)
     mkpath(output_directory)
 
+    # Skip empty systems
+    if nparticles(system_) == 0
+        return
+    end
+
     # Transfer to CPU if data is on the GPU. Do nothing if already on CPU.
     v, u, system = transfer2cpu(v_, u_, system_)
 


### PR DESCRIPTION
With open boundaries a system can be empty. Lets skip them in the IO step.

Extracted from #604 