### PR TITLE
Fix callback `show` and remove hacky workaround

### DIFF
--- a/src/callbacks/solution_saving.jl
+++ b/src/callbacks/solution_saving.jl
@@ -217,8 +217,8 @@ end
 # - `DiscreteCallback{<:Any, <:SolutionSavingCallback}`.
 #
 # With `interval`
-function Base.show(io::IO, cb::DiscreteCallback{<:SolutionSavingCallback,
-                                                <:SolutionSavingCallback})
+function Base.show(io::IO,
+                   cb::DiscreteCallback{<:SolutionSavingCallback, <:SolutionSavingCallback})
     @nospecialize cb # reduce precompilation time
 
     solution_saving = cb.affect!

--- a/src/callbacks/solution_saving.jl
+++ b/src/callbacks/solution_saving.jl
@@ -240,7 +240,7 @@ function Base.show(io::IO,
                    cb::DiscreteCallback{<:Any, <:SolutionSavingCallback})
     @nospecialize cb # reduce precompilation time
 
-    solution_saving = cb.finalize
+    solution_saving = cb.affect!
     print(io, "SolutionSavingCallback(save_times=", solution_saving.save_times, ")")
 end
 
@@ -303,7 +303,7 @@ function Base.show(io::IO, ::MIME"text/plain",
     if get(io, :compact, false)
         show(io, cb)
     else
-        solution_saving = cb.finalize
+        solution_saving = cb.affect!
         cq = collect(solution_saving.custom_quantities)
 
         setup = [

--- a/src/callbacks/solution_saving.jl
+++ b/src/callbacks/solution_saving.jl
@@ -106,8 +106,7 @@ function SolutionSavingCallback(; interval::Integer=0, dt=0.0,
                                                -1, Ref("UnknownVersion"))
 
     if length(save_times) > 0
-        # See the large comment below for an explanation why we use `finalize` here
-        return PresetTimeCallback(save_times, solution_callback, finalize=solution_callback)
+        return PresetTimeCallback(save_times, solution_callback)
     elseif dt > 0
         # Add a `tstop` every `dt`, and save the final solution
         return PeriodicCallback(solution_callback, dt,
@@ -191,31 +190,42 @@ function (solution_callback::SolutionSavingCallback)(integrator)
     return nothing
 end
 
-# `finalize`
-# This is a hack to make dispatch on a `PresetTimeCallback` possible.
+# The type of the `DiscreteCallback` returned by the constructor is
+# `DiscreteCallback{typeof(condition), typeof(affect!), typeof(initialize)}`.
 #
-# The type of the returned `DiscreteCallback` is
-# `DiscreteCallback{typeof(condition), typeof(affect!), typeof(initialize), typeof(finalize)}`.
-# For the `PeriodicCallback`, `typeof(affect!)` contains the type of the
-# `SolutionSavingCallback`. The `PresetTimeCallback` uses anonymous functions as `condition`
-# and `affect!`, so this doesn't work here.
+# When `interval` is used, this is
+# `DiscreteCallback{<:SolutionSavingCallback,
+#                   <:SolutionSavingCallback,
+#                   typeof(TrixiParticles.initialize_save_cb!),
+#                   typeof(SciMLBase.FINALIZE_DEFAULT)}`.
 #
-# This hacky workaround makes use of the type parameter `typeof(finalize)` above.
-# It's set to `FINALIZE_DEFAULT` by default in the `PresetTimeCallback`, which is a function
-# that just returns `nothing`.
-# Instead, we pass the `SolutionSavingCallback` as `finalize`, and define it to also just
-# return `nothing` when called as `initialize`.
-function (finalize::SolutionSavingCallback)(c, u, t, integrator)
-    return nothing
-end
-
-function Base.show(io::IO, cb::DiscreteCallback{<:Any, <:SolutionSavingCallback})
+# When `dt` is used, this is
+# `DiscreteCallback{DiffEqCallbacks.var"#99#103"{...},
+#                   DiffEqCallbacks.PeriodicCallbackAffect{<:SolutionSavingCallback},
+#                   DiffEqCallbacks.var"#100#104"{...}
+#                   typeof(SciMLBase.FINALIZE_DEFAULT)}`.
+#
+# When `save_times` is used, this is
+# `DiscreteCallback{DiffEqCallbacks.var"#115#117"{...},
+#                   <:SolutionSavingCallback,
+#                   DiffEqCallbacks.var"#116#118"{...},
+#                   <:SolutionSavingCallback}`.
+#
+# So we can unambiguously dispatch on
+# - `DiscreteCallback{<:SolutionSavingCallback, <:SolutionSavingCallback}`,
+# - `DiscreteCallback{<:Any, <:PeriodicCallbackAffect{<:SolutionSavingCallback}}`,
+# - `DiscreteCallback{<:Any, <:SolutionSavingCallback}`.
+#
+# With `interval`
+function Base.show(io::IO, cb::DiscreteCallback{<:SolutionSavingCallback,
+                                                <:SolutionSavingCallback})
     @nospecialize cb # reduce precompilation time
 
     solution_saving = cb.affect!
     print(io, "SolutionSavingCallback(interval=", solution_saving.interval, ")")
 end
 
+# With `dt`
 function Base.show(io::IO,
                    cb::DiscreteCallback{<:Any,
                                         <:PeriodicCallbackAffect{<:SolutionSavingCallback}})
@@ -225,16 +235,18 @@ function Base.show(io::IO,
     print(io, "SolutionSavingCallback(dt=", solution_saving.interval, ")")
 end
 
+# With `save_times`
 function Base.show(io::IO,
-                   cb::DiscreteCallback{<:Any, <:Any, <:Any, <:SolutionSavingCallback})
+                   cb::DiscreteCallback{<:Any, <:SolutionSavingCallback})
     @nospecialize cb # reduce precompilation time
 
     solution_saving = cb.finalize
     print(io, "SolutionSavingCallback(save_times=", solution_saving.save_times, ")")
 end
 
+# With `interval`
 function Base.show(io::IO, ::MIME"text/plain",
-                   cb::DiscreteCallback{<:Any, <:SolutionSavingCallback})
+                   cb::DiscreteCallback{<:SolutionSavingCallback, <:SolutionSavingCallback})
     @nospecialize cb # reduce precompilation time
 
     if get(io, :compact, false)
@@ -257,30 +269,7 @@ function Base.show(io::IO, ::MIME"text/plain",
     end
 end
 
-function Base.show(io::IO, ::MIME"text/plain",
-                   cb::DiscreteCallback{<:Any, <:Any, <:Any, <:SolutionSavingCallback})
-    @nospecialize cb # reduce precompilation time
-
-    if get(io, :compact, false)
-        show(io, cb)
-    else
-        solution_saving = cb.finalize
-        cq = collect(solution_saving.custom_quantities)
-
-        setup = [
-            "save_times" => solution_saving.save_times,
-            "custom quantities" => isempty(cq) ? nothing : cq,
-            "save initial solution" => solution_saving.save_initial_solution ?
-                                       "yes" : "no",
-            "save final solution" => solution_saving.save_final_solution ? "yes" :
-                                     "no",
-            "output directory" => abspath(solution_saving.output_directory),
-            "prefix" => solution_saving.prefix
-        ]
-        summary_box(io, "SolutionSavingCallback", setup)
-    end
-end
-
+# With `dt`
 function Base.show(io::IO, ::MIME"text/plain",
                    cb::DiscreteCallback{<:Any,
                                         <:PeriodicCallbackAffect{<:SolutionSavingCallback}})
@@ -294,6 +283,31 @@ function Base.show(io::IO, ::MIME"text/plain",
 
         setup = [
             "dt" => solution_saving.interval,
+            "custom quantities" => isempty(cq) ? nothing : cq,
+            "save initial solution" => solution_saving.save_initial_solution ?
+                                       "yes" : "no",
+            "save final solution" => solution_saving.save_final_solution ? "yes" :
+                                     "no",
+            "output directory" => abspath(solution_saving.output_directory),
+            "prefix" => solution_saving.prefix
+        ]
+        summary_box(io, "SolutionSavingCallback", setup)
+    end
+end
+
+# With `save_times`
+function Base.show(io::IO, ::MIME"text/plain",
+                   cb::DiscreteCallback{<:Any, <:SolutionSavingCallback})
+    @nospecialize cb # reduce precompilation time
+
+    if get(io, :compact, false)
+        show(io, cb)
+    else
+        solution_saving = cb.finalize
+        cq = collect(solution_saving.custom_quantities)
+
+        setup = [
+            "save_times" => solution_saving.save_times,
             "custom quantities" => isempty(cq) ? nothing : cq,
             "save initial solution" => solution_saving.save_initial_solution ?
                                        "yes" : "no",

--- a/test/callbacks/solution_saving.jl
+++ b/test/callbacks/solution_saving.jl
@@ -44,7 +44,7 @@
             @test repr("text/plain", callback) == show_box
         end
 
-        @testset verbose=true "interval" begin
+        @testset verbose=true "save_times" begin
             callback = SolutionSavingCallback(save_times=[1.0, 2.0, 3.0], prefix="test",
                                               output_directory=out)
 


### PR DESCRIPTION
Fixes the failing CI on main after https://github.com/JuliaSIMD/StrideArrays.jl/issues/92 allows us to use DiffEqCallbacks version 4.