### PR TITLE
[Proof of Concept] Constant-propagate `sqrt(eps())` on GPUs

### DIFF
--- a/src/general/smoothing_kernels.jl
+++ b/src/general/smoothing_kernels.jl
@@ -2,9 +2,12 @@ abstract type SmoothingKernel{NDIMS} end
 
 @inline Base.ndims(::SmoothingKernel{NDIMS}) where {NDIMS} = NDIMS
 
+@eval sqrt_eps(::Type{Float32}) = $(sqrt(eps(Float32)))
+@eval sqrt_eps(::Type{Float64}) = $(sqrt(eps(Float64)))
+
 @inline function kernel_grad(kernel, pos_diff, distance, h)
     # TODO Use `eps` relative to `h` to allow scaling of simulations
-    distance < sqrt(eps(typeof(h))) && return zero(pos_diff)
+    distance < sqrt_eps(typeof(h)) && return zero(pos_diff)
 
     return kernel_deriv(kernel, distance, h) / distance * pos_diff
 end

--- a/src/schemes/fluid/weakly_compressible_sph/density_diffusion.jl
+++ b/src/schemes/fluid/weakly_compressible_sph/density_diffusion.jl
@@ -178,7 +178,7 @@ function update!(density_diffusion::DensityDiffusionAntuono, neighborhood_search
     foreach_point_neighbor(system, system, system_coords, system_coords,
                            neighborhood_search) do particle, neighbor, pos_diff, distance
         # Only consider particles with a distance > 0
-        distance < sqrt(eps(typeof(distance))) && return
+        distance < sqrt_eps(typeof(distance)) && return
 
         rho_a = particle_density(v, system, particle)
         rho_b = particle_density(v, system, neighbor)
@@ -204,7 +204,7 @@ end
                                                 pos_diff, distance, m_b, rho_a, rho_b,
                                                 particle_system::FluidSystem, grad_kernel)
     # Density diffusion terms are all zero for distance zero
-    distance < sqrt(eps(typeof(distance))) && return
+    distance < sqrt_eps(typeof(distance)) && return
 
     (; delta) = density_diffusion
     (; smoothing_length, state_equation) = particle_system


### PR DESCRIPTION
This didn't make a significant difference in benchmarks, but I would like to put it here in case we need it or want to run another benchmark.