### PR TITLE
Make `load_geometry` type stable

### DIFF
--- a/src/preprocessing/geometries/io.jl
+++ b/src/preprocessing/geometries/io.jl
@@ -65,8 +65,8 @@ function load_data!(face_vertices::Vector{Tuple{SVector{3, T}, SVector{3, T},
                     vertices, normals, io) where {T}
     i = 0
     while !eof(io)
-        normal = (read(io, Float32), read(io, Float32), read(io, Float32))
-        normals[i + 1] = SVector{3, T}(normal...)
+        normals[i + 1] = SVector{3, T}(read(io, Float32), read(io, Float32),
+                                       read(io, Float32))
 
         v1 = SVector{3, T}(read(io, Float32), read(io, Float32), read(io, Float32))
         v2 = SVector{3, T}(read(io, Float32), read(io, Float32), read(io, Float32))
@@ -74,9 +74,9 @@ function load_data!(face_vertices::Vector{Tuple{SVector{3, T}, SVector{3, T},
 
         face_vertices[i + 1] = (v1, v2, v3)
 
-        vertices[3 * i + 1] = face_vertices[i + 1][1]
-        vertices[3 * i + 2] = face_vertices[i + 1][2]
-        vertices[3 * i + 3] = face_vertices[i + 1][3]
+        vertices[3 * i + 1] = v1
+        vertices[3 * i + 2] = v2
+        vertices[3 * i + 3] = v3
 
         # After the 48 bytes of the normal and the vertices follows a 2-byte unsigned integer
         # that is the "attribute byte count" – in the standard format, this should be zero

--- a/src/preprocessing/geometries/io.jl
+++ b/src/preprocessing/geometries/io.jl
@@ -68,12 +68,11 @@ function load_data!(face_vertices::Vector{Tuple{SVector{3, T}, SVector{3, T},
         normal = (read(io, Float32), read(io, Float32), read(io, Float32))
         normals[i + 1] = SVector{3, T}(normal...)
 
-        v1 = (read(io, Float32), read(io, Float32), read(io, Float32))
-        v2 = (read(io, Float32), read(io, Float32), read(io, Float32))
-        v3 = (read(io, Float32), read(io, Float32), read(io, Float32))
+        v1 = SVector{3, T}(read(io, Float32), read(io, Float32), read(io, Float32))
+        v2 = SVector{3, T}(read(io, Float32), read(io, Float32), read(io, Float32))
+        v3 = SVector{3, T}(read(io, Float32), read(io, Float32), read(io, Float32))
 
-        face_vertices[i + 1] = (SVector{3, T}(v1...), SVector{3, T}(v2...),
-                                SVector{3, T}(v3...))
+        face_vertices[i + 1] = (v1, v2, v3)
 
         vertices[3 * i + 1] = face_vertices[i + 1][1]
         vertices[3 * i + 2] = face_vertices[i + 1][2]


### PR DESCRIPTION
`load_geometry(file)`, where `file` is a ~7.4MB large (~150k faces) stl-file:
 ### `main`
```julia
julia> @benchmark load_geometry($file)
BenchmarkTools.Trial: 4 samples with 1 evaluation.
 Range (min … max):  1.529 s …   1.596 s  ┊ GC (min … max): 1.07% … 3.03%
 Time  (median):     1.571 s              ┊ GC (median):    1.03%
 Time  (mean ± σ):   1.567 s ± 30.554 ms  ┊ GC (mean ± σ):  1.51% ± 1.01%

  █                      █                        █       █  
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁█ ▁
  1.53 s         Histogram: frequency by time         1.6 s <

 Memory estimate: 529.69 MiB, allocs estimate: 11601626.
```

### This PR
```julia
julia> @benchmark load_geometry($file)
BenchmarkTools.Trial: 72 samples with 1 evaluation.
 Range (min … max):  61.315 ms … 113.754 ms  ┊ GC (min … max): 0.00% … 7.92%
 Time  (median):     69.208 ms               ┊ GC (median):    4.10%
 Time  (mean ± σ):   69.877 ms ±   6.842 ms  ┊ GC (mean ± σ):  3.92% ± 1.99%

                ▅█ ▂▂        ▂         ▂      ▂  ▅              
  ▅▅▅▁█▁▁▁▅█▅▅████▅██▅▁▅▅▁█▁▁█▁▁▅▅█▅█▁▅███▅▅█▁█▅▁█▁▁▅█▁▅▅▁▁▁▁▅ ▁
  61.3 ms         Histogram: frequency by time         78.6 ms <

 Memory estimate: 89.37 MiB, allocs estimate: 191.
``` 