### PR TITLE
Code to reproduce Heisenbug with Metal.jl

### DIFF
--- a/examples/fluid/dam_break_3d.jl
+++ b/examples/fluid/dam_break_3d.jl
@@ -57,7 +57,7 @@ boundary_system = BoundarySPHSystem(tank.boundary, boundary_model)
 # ==========================================================================================
 # ==== Simulation
 semi = Semidiscretization(fluid_system, boundary_system)
-ode = semidiscretize(semi, tspan)
+ode = semidiscretize(semi, tspan, data_type=nothing)
 
 info_callback = InfoCallback(interval=10)
 saving_callback = SolutionSavingCallback(dt=0.02, prefix="")

--- a/examples/test2.jl
+++ b/examples/test2.jl
@@ -1,0 +1,23 @@
+using Metal, TrixiParticles
+
+# Import variables into scope
+trixi_include_changeprecision(Float32, @__MODULE__,
+joinpath(examples_dir(), "fluid",
+         "dam_break_3d.jl"),
+fluid_particle_spacing=0.1,
+sol=nothing, ode=nothing)
+
+# Neighborhood search with `FullGridCellList` for GPU compatibility
+min_corner = minimum(tank.boundary.coordinates, dims=2)
+max_corner = maximum(tank.boundary.coordinates, dims=2)
+cell_list = FullGridCellList(; min_corner, max_corner)
+semi_fullgrid = Semidiscretization(fluid_system, boundary_system,
+     neighborhood_search=GridNeighborhoodSearch{3}(; cell_list))
+
+trixi_include_changeprecision(Float32, @__MODULE__,
+                 joinpath(examples_dir(), "fluid",
+                          "dam_break_3d.jl"),
+                 tspan=(0.0f0, 0.1f0),
+                 fluid_particle_spacing=0.1,
+                 semi=semi_fullgrid,
+                 data_type=MtlArray, maxiters=0)

--- a/src/general/semidiscretization.jl
+++ b/src/general/semidiscretization.jl
@@ -445,13 +445,7 @@ function test1()
     dv = Main.Metal.zeros(4, 1)
     dv .= 0
     backend = KernelAbstractions.get_backend(dv)
-    mykernel(backend)(ndrange = 1) do _
-        x = SVector(5.8251f-19, 1.1650201f-18, 1.16502f-18)
-
-        for i in 1:3
-            dv[i] += x[i]
-        end
-    end
+    mykernel(backend)(dv, ndrange = 1)
     KernelAbstractions.synchronize(backend)
     if any(>(0.1f0), dv)
         @error "" dv[:, 1]
@@ -459,9 +453,12 @@ function test1()
     end
 end
 
-@kernel function mykernel(f)
-    i = @index(Global)
-    @inline f(i)
+@kernel function mykernel(dv)
+    j = @index(Global)
+    x = SVector(5.8251f-19, 1.1650201f-18, 1.16502f-18)
+    for i in 1:3
+        dv[i] += x[i]
+    end
 end
 
 function kick!(dv_ode, v_ode, u_ode, semi, t)


### PR DESCRIPTION
This PR is to reproduce the Heisenbug with Metal.jl, which makes certain simulations fail on Metal.
I reduced it to this minimal example, but unfortunately, it only triggers the bug when I replace the actual simulation code (the function `kick!`) with the call to `test1` and then run this simulation in `examples/test2.jl`. Maybe the GPU allocations there are necessary to trigger the bug?

To trigger this bug, I include this file a hundred times by copying this into the REPL:
```
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
include("examples/test2.jl");
```
These are 50 lines, so the file is included 50 times. 
I often have to run it several hundred times to trigger the bug, but then I often get it multiple times in a row.
When the bug is triggered, it prints something like this and then the output stops for 5 seconds:
```
┌ Error: 
│   dv[:, 1] =
│    4-element MtlVector{Float32, Metal.PrivateStorage}:
│     123.78716
│     123.78716
│     123.78716
│       0.0
└ @ TrixiParticles ~/git/TrixiParticles.jl/src/general/semidiscretization.jl:457
```
This should be almost zero, and certainly not 123.78716.