### PR TITLE
write2json

### DIFF
--- a/examples/fluid/falling_water_spheres_2d.jl
+++ b/examples/fluid/falling_water_spheres_2d.jl
@@ -87,8 +87,7 @@ semi = Semidiscretization(sphere_surface_tension, sphere, boundary_system)
 ode = semidiscretize(semi, tspan)
 
 info_callback = InfoCallback(interval=50)
-saving_callback = SolutionSavingCallback(dt=0.01, output_directory="out",
-                                         prefix="", write_meta_data=true)
+saving_callback = SolutionSavingCallback(dt=0.01, output_directory="out", prefix="")
 
 callbacks = CallbackSet(info_callback, saving_callback)
 

--- a/examples/fsi/falling_sphere_3d.jl
+++ b/examples/fsi/falling_sphere_3d.jl
@@ -10,5 +10,4 @@ trixi_include(@__MODULE__,
               solid_smoothing_kernel=WendlandC2Kernel{3}(),
               sphere_type=RoundSphere(),
               output_directory="out", prefix="",
-              write_meta_data=false, # Files with meta data can't be read by meshio
               tspan=(0.0, 1.0), abstol=1e-6, reltol=1e-3)

--- a/examples/fsi/falling_spheres_2d.jl
+++ b/examples/fsi/falling_spheres_2d.jl
@@ -117,8 +117,7 @@ semi = Semidiscretization(fluid_system, boundary_system, solid_system_1, solid_s
 ode = semidiscretize(semi, tspan)
 
 info_callback = InfoCallback(interval=10)
-saving_callback = SolutionSavingCallback(dt=0.02, output_directory="out", prefix="",
-                                         write_meta_data=true)
+saving_callback = SolutionSavingCallback(dt=0.02, output_directory="out", prefix="")
 
 callbacks = CallbackSet(info_callback, saving_callback)
 

--- a/examples/n_body/n_body_system.jl
+++ b/examples/n_body/n_body_system.jl
@@ -110,7 +110,7 @@ end
 
 TrixiParticles.vtkname(system::NBodySystem) = "n-body"
 
-function TrixiParticles.write2vtk!(vtk, v, u, t, system::NBodySystem; write_meta_data=true)
+function TrixiParticles.write2vtk!(vtk, v, u, t, system::NBodySystem)
     (; mass) = system
 
     vtk["velocity"] = v

--- a/src/TrixiParticles.jl
+++ b/src/TrixiParticles.jl
@@ -52,6 +52,7 @@ include("schemes/schemes.jl")
 include("general/semidiscretization.jl")
 include("general/gpu.jl")
 include("visualization/write2vtk.jl")
+include("visualization/write2json.jl")
 include("visualization/recipes_plots.jl")
 include("preprocessing/preprocessing.jl")
 
@@ -77,7 +78,7 @@ export BoundaryModelMonaghanKajtar, BoundaryModelDummyParticles, AdamiPressureEx
 
 export BoundaryMovement
 export examples_dir, validation_dir
-export trixi2vtk
+export trixi2vtk, trixi2json
 export RectangularTank, RectangularShape, SphereShape, ComplexShape
 export ParticlePackingSystem, SignedDistanceField
 export WindingNumberHormann, WindingNumberJacobson

--- a/src/callbacks/solution_saving.jl
+++ b/src/callbacks/solution_saving.jl
@@ -133,6 +133,11 @@ function initialize_save_cb!(solution_callback::SolutionSavingCallback, u, t, in
     solution_callback.latest_saved_iter = -1
     solution_callback.git_hash[] = compute_git_hash()
 
+    # Write metadata to JSON-file
+    if integrator.iter == 0
+        trixi2json(solution_callback, integrator)
+    end
+
     # Save initial solution
     if solution_callback.save_initial_solution
         # Update systems to compute quantities like density and pressure

--- a/src/callbacks/solution_saving.jl
+++ b/src/callbacks/solution_saving.jl
@@ -2,8 +2,7 @@
     SolutionSavingCallback(; interval::Integer=0, dt=0.0, save_times=Array{Float64, 1}([]),
                            save_initial_solution=true, save_final_solution=true,
                            output_directory="out", append_timestamp=false, prefix="",
-                           verbose=false, write_meta_data=true, max_coordinates=2^15,
-                           custom_quantities...)
+                           verbose=false, max_coordinates=2^15, custom_quantities...)
 
 
 Callback to save the current numerical solution in VTK format in regular intervals.
@@ -28,7 +27,6 @@ To ignore a custom quantity for a specific system, return `nothing`.
 - `append_timestamp=false`:     Append current timestamp to the output directory.
 - 'prefix=""':                  Prefix added to the filename.
 - `custom_quantities...`:       Additional user-defined quantities.
-- `write_meta_data=true`:       Write meta data.
 - `verbose=false`:              Print to standard IO when a file is written.
 - `max_coordinates=2^15`:       The coordinates of particles will be clipped if their
                                 absolute values exceed this threshold.
@@ -70,7 +68,6 @@ mutable struct SolutionSavingCallback{I, CQ}
     save_times            :: Vector{Float64}
     save_initial_solution :: Bool
     save_final_solution   :: Bool
-    write_meta_data       :: Bool
     verbose               :: Bool
     output_directory      :: String
     prefix                :: String
@@ -84,8 +81,8 @@ function SolutionSavingCallback(; interval::Integer=0, dt=0.0,
                                 save_times=Float64[],
                                 save_initial_solution=true, save_final_solution=true,
                                 output_directory="out", append_timestamp=false,
-                                prefix="", verbose=false, write_meta_data=true,
-                                max_coordinates=Float64(2^15), custom_quantities...)
+                                prefix="", verbose=false, max_coordinates=Float64(2^15),
+                                custom_quantities...)
     if (dt > 0 && interval > 0) || (length(save_times) > 0 && (dt > 0 || interval > 0))
         throw(ArgumentError("Setting multiple save times for the same solution " *
                             "callback is not possible. Use either `dt`, `interval` or `save_times`."))
@@ -101,8 +98,8 @@ function SolutionSavingCallback(; interval::Integer=0, dt=0.0,
 
     solution_callback = SolutionSavingCallback(interval, Float64.(save_times),
                                                save_initial_solution, save_final_solution,
-                                               write_meta_data, verbose, output_directory,
-                                               prefix, max_coordinates, custom_quantities,
+                                               verbose, output_directory, prefix,
+                                               max_coordinates, custom_quantities,
                                                -1, Ref("UnknownVersion"))
 
     if length(save_times) > 0
@@ -162,8 +159,8 @@ end
 
 # `affect!`
 function (solution_callback::SolutionSavingCallback)(integrator)
-    (; interval, output_directory, custom_quantities, write_meta_data, git_hash,
-    verbose, prefix, latest_saved_iter, max_coordinates) = solution_callback
+    (; interval, output_directory, custom_quantities, git_hash, verbose,
+    prefix, latest_saved_iter, max_coordinates) = solution_callback
 
     vu_ode = integrator.u
     semi = integrator.p
@@ -186,8 +183,8 @@ function (solution_callback::SolutionSavingCallback)(integrator)
 
     @trixi_timeit timer() "save solution" trixi2vtk(vu_ode, semi, integrator.t;
                                                     iter, output_directory, prefix,
-                                                    write_meta_data, git_hash=git_hash[],
-                                                    max_coordinates, custom_quantities...)
+                                                    git_hash=git_hash[], max_coordinates,
+                                                    custom_quantities...)
 
     # Tell OrdinaryDiffEq that `u` has not been modified
     u_modified!(integrator, false)

--- a/src/preprocessing/particle_packing/system.jl
+++ b/src/preprocessing/particle_packing/system.jl
@@ -142,10 +142,8 @@ end
 
 update_callback_used!(system::ParticlePackingSystem) = system.update_callback_used[] = true
 
-function write2vtk!(vtk, v, u, t, system::ParticlePackingSystem; write_meta_data=true)
-    if write_meta_data
+function write2vtk!(vtk, v, u, t, system::ParticlePackingSystem)
         vtk["signed_distances"] = system.signed_distances
-    end
 end
 
 write_v0!(v0, system::ParticlePackingSystem) = v0 .= zero(eltype(system))

--- a/src/preprocessing/particle_packing/system.jl
+++ b/src/preprocessing/particle_packing/system.jl
@@ -143,7 +143,7 @@ end
 update_callback_used!(system::ParticlePackingSystem) = system.update_callback_used[] = true
 
 function write2vtk!(vtk, v, u, t, system::ParticlePackingSystem)
-        vtk["signed_distances"] = system.signed_distances
+    vtk["signed_distances"] = system.signed_distances
 end
 
 write_v0!(v0, system::ParticlePackingSystem) = v0 .= zero(eltype(system))

--- a/src/visualization/write2json.jl
+++ b/src/visualization/write2json.jl
@@ -17,136 +17,137 @@ setup = :(trixi_include(@__MODULE__, joinpath(examples_dir(), "fluid", "hydrosta
 """
 
 function trixi2json(solution_callback, integrator)
+    semi = integrator.p
+    (; systems) = semi
 
-	semi = integrator.p
-	(; systems) = semi
+    output_directory = solution_callback.output_directory
+    prefix = solution_callback.prefix
+    git_hash = solution_callback.git_hash
 
-	output_directory = solution_callback.output_directory
-	prefix = solution_callback.prefix
-	git_hash = solution_callback.git_hash
+    filenames = system_names(systems)
 
-	filenames = system_names(systems)
+    foreach_system(semi) do system
+        system_index = system_indices(system, semi)
 
-	foreach_system(semi) do system
-		system_index = system_indices(system, semi)
-
-		trixi2json(system; system_name = filenames[system_index], output_directory, prefix, git_hash)
-	end
+        trixi2json(system; system_name=filenames[system_index], output_directory, prefix,
+                   git_hash)
+    end
 end
 
 function trixi2json(system; system_name, output_directory, prefix, git_hash)
-	mkpath(output_directory)
+    mkpath(output_directory)
 
-	meta_data = Dict{String, Any}(
-		"solver_version" => git_hash,
-		"julia_version" => string(VERSION),
-	)
+    meta_data = Dict{String, Any}(
+        "solver_name" => "TrixiParticles.jl",
+        "solver_version" => git_hash,
+        "julia_version" => string(VERSION)
+    )
 
-	get_meta_data!(meta_data, system)
+    get_meta_data!(meta_data, system)
 
-	# handle "_" on optional prefix strings
-	add_opt_str_pre(str) = (str === "" ? "" : "$(str)_")
+    # handle "_" on optional prefix strings
+    add_opt_str_pre(str) = (str === "" ? "" : "$(str)_")
 
-	# Write metadata to JSON-file
-	json_file = joinpath(output_directory,
-		add_opt_str_pre(prefix) * "$(system_name)_metadata.json")
+    # Write metadata to JSON-file
+    json_file = joinpath(output_directory,
+                         add_opt_str_pre(prefix) * "$(system_name)_metadata.json")
 
-	open(json_file, "w") do file
-		JSON.print(file, meta_data, 2)
-	end
+    open(json_file, "w") do file
+        JSON.print(file, meta_data, 2)
+    end
 end
 
 function get_meta_data!(meta_data, system::FluidSystem)
-	meta_data["acceleration"] = system.acceleration
-	meta_data["viscosity"] = type2string(system.viscosity)
-	get_meta_data!(meta_data, system.viscosity)
-	meta_data["smoothing_kernel"] = type2string(system.smoothing_kernel)
-	meta_data["smoothing_length"] = system.smoothing_length
-	meta_data["density_calculator"] = type2string(system.density_calculator)
+    meta_data["acceleration"] = system.acceleration
+    meta_data["viscosity"] = type2string(system.viscosity)
+    get_meta_data!(meta_data, system.viscosity)
+    meta_data["smoothing_kernel"] = type2string(system.smoothing_kernel)
+    meta_data["smoothing_length"] = system.smoothing_length
+    meta_data["density_calculator"] = type2string(system.density_calculator)
 
-	if system isa WeaklyCompressibleSPHSystem
-		meta_data["state_equation"] = type2string(system.state_equation)
-		meta_data["state_equation_rho0"] = system.state_equation.reference_density
-		meta_data["state_equation_pa"] = system.state_equation.background_pressure
-		meta_data["state_equation_c"] = system.state_equation.sound_speed
-		meta_data["solver"] = "WCSPH"
+    if system isa WeaklyCompressibleSPHSystem
+        meta_data["state_equation"] = type2string(system.state_equation)
+        meta_data["state_equation_rho0"] = system.state_equation.reference_density
+        meta_data["state_equation_pa"] = system.state_equation.background_pressure
+        meta_data["state_equation_c"] = system.state_equation.sound_speed
+        meta_data["solver"] = "WCSPH"
 
-		meta_data["correction_method"] = type2string(system.correction)
-		if system.correction isa AkinciFreeSurfaceCorrection
-			meta_data["correction_rho0"] = system.correction.rho0
-		end
-		if system.state_equation isa StateEquationCole
-			meta_data["state_equation_exponent"] = system.state_equation.exponent
-		end
-		if system.state_equation isa StateEquationIdealGas
-			meta_data["state_equation_gamma"] = system.state_equation.gamma
-		end
-	else
-		meta_data["solver"] = "EDAC"
-		meta_data["sound_speed"] = system.sound_speed
-		meta_data["background_pressure_TVF"] = system.transport_velocity isa Nothing ? "-" :
-											   system.transport_velocity.background_pressure
-	end
+        meta_data["correction_method"] = type2string(system.correction)
+        if system.correction isa AkinciFreeSurfaceCorrection
+            meta_data["correction_rho0"] = system.correction.rho0
+        end
+        if system.state_equation isa StateEquationCole
+            meta_data["state_equation_exponent"] = system.state_equation.exponent
+        end
+        if system.state_equation isa StateEquationIdealGas
+            meta_data["state_equation_gamma"] = system.state_equation.gamma
+        end
+    else
+        meta_data["solver"] = "EDAC"
+        meta_data["sound_speed"] = system.sound_speed
+        meta_data["background_pressure_TVF"] = system.transport_velocity isa Nothing ? "-" :
+                                               system.transport_velocity.background_pressure
+    end
 
-	return meta_data
+    return meta_data
 end
 
 get_meta_data!(meta_data, viscosity::Nothing) = meta_data
 
 function get_meta_data!(meta_data, viscosity::Union{ViscosityAdami, ViscosityMorris})
-	meta_data["viscosity_nu"] = viscosity.nu
-	meta_data["viscosity_epsilon"] = viscosity.epsilon
+    meta_data["viscosity_nu"] = viscosity.nu
+    meta_data["viscosity_epsilon"] = viscosity.epsilon
 end
 
 function get_meta_data!(meta_data, viscosity::ArtificialViscosityMonaghan)
-	meta_data["viscosity_alpha"] = viscosity.alpha
-	meta_data["viscosity_beta"] = viscosity.beta
-	meta_data["viscosity_epsilon"] = viscosity.epsilon
+    meta_data["viscosity_alpha"] = viscosity.alpha
+    meta_data["viscosity_beta"] = viscosity.beta
+    meta_data["viscosity_epsilon"] = viscosity.epsilon
 end
 
 function get_meta_data!(meta_data, system::TotalLagrangianSPHSystem)
-	meta_data["young_modulus"] = system.young_modulus
-	meta_data["poisson_ratio"] = system.poisson_ratio
-	meta_data["lame_lambda"] = system.lame_lambda
-	meta_data["lame_mu"] = system.lame_mu
-	meta_data["smoothing_kernel"] = type2string(system.smoothing_kernel)
-	meta_data["smoothing_length"] = system.smoothing_length
+    meta_data["young_modulus"] = system.young_modulus
+    meta_data["poisson_ratio"] = system.poisson_ratio
+    meta_data["lame_lambda"] = system.lame_lambda
+    meta_data["lame_mu"] = system.lame_mu
+    meta_data["smoothing_kernel"] = type2string(system.smoothing_kernel)
+    meta_data["smoothing_length"] = system.smoothing_length
 
-	get_meta_data!(meta_data, system.boundary_model, system)
+    get_meta_data!(meta_data, system.boundary_model, system)
 end
 
 function get_meta_data!(meta_data, system::OpenBoundarySPHSystem)
-	meta_data["boundary_zone"] = type2string(system.boundary_zone)
-	meta_data["width"] = round(system.boundary_zone.zone_width, digits = 3)
-	meta_data["flow_direction"] = system.flow_direction
-	meta_data["velocity_function"] = type2string(system.reference_velocity)
-	meta_data["pressure_function"] = type2string(system.reference_pressure)
-	meta_data["density_function"] = type2string(system.reference_density)
+    meta_data["boundary_zone"] = type2string(system.boundary_zone)
+    meta_data["width"] = round(system.boundary_zone.zone_width, digits=3)
+    meta_data["flow_direction"] = system.flow_direction
+    meta_data["velocity_function"] = type2string(system.reference_velocity)
+    meta_data["pressure_function"] = type2string(system.reference_pressure)
+    meta_data["density_function"] = type2string(system.reference_density)
 end
 
 function get_meta_data!(meta_data, system::BoundarySPHSystem)
-	get_meta_data!(meta_data, system.boundary_model, system)
+    get_meta_data!(meta_data, system.boundary_model, system)
 end
 
 function get_meta_data!(meta_data, model, system)
-	return meta_data
+    return meta_data
 end
 
 function get_meta_data!(meta_data, model::BoundaryModelMonaghanKajtar, system)
-	meta_data["boundary_model"] = "BoundaryModelMonaghanKajtar"
-	meta_data["boundary_spacing_ratio"] = model.beta
-	meta_data["boundary_K"] = model.K
+    meta_data["boundary_model"] = "BoundaryModelMonaghanKajtar"
+    meta_data["boundary_spacing_ratio"] = model.beta
+    meta_data["boundary_K"] = model.K
 end
 
 function get_meta_data!(meta_data, model::BoundaryModelDummyParticles, system)
-	meta_data["boundary_model"] = "BoundaryModelDummyParticles"
-	meta_data["smoothing_kernel"] = type2string(model.smoothing_kernel)
-	meta_data["smoothing_length"] = model.smoothing_length
-	meta_data["density_calculator"] = type2string(model.density_calculator)
-	meta_data["state_equation"] = type2string(model.state_equation)
-	meta_data["viscosity_model"] = type2string(model.viscosity)
+    meta_data["boundary_model"] = "BoundaryModelDummyParticles"
+    meta_data["smoothing_kernel"] = type2string(model.smoothing_kernel)
+    meta_data["smoothing_length"] = model.smoothing_length
+    meta_data["density_calculator"] = type2string(model.density_calculator)
+    meta_data["state_equation"] = type2string(model.state_equation)
+    meta_data["viscosity_model"] = type2string(model.viscosity)
 end
 
 function get_meta_data!(meta_data, system::BoundaryDEMSystem)
-	return meta_data
+    return meta_data
 end

--- a/src/visualization/write2json.jl
+++ b/src/visualization/write2json.jl
@@ -1,0 +1,152 @@
+"""
+	trixi2json(solution_callback, integrator)
+
+Write simulation metadata to a JSON-file.
+
+# Arguments
+- `solution_callback`:  Callback storing metadata and output settings.
+- `integrator`:         ODE integrator containing simulation data.
+
+# Example
+```jldoctest; output = false, saving_callback = SolutionSavingCallback(dt = 0.1, output_directory = "output", prefix = "solution"),
+setup = :(trixi_include(@__MODULE__, joinpath(examples_dir(), "fluid", "hydrostatic_water_column_2d.jl"), tspan = (0.0, 0.01), callbacks = saving_callback))
+
+# output
+
+```
+"""
+
+function trixi2json(solution_callback, integrator)
+
+	semi = integrator.p
+	(; systems) = semi
+
+	output_directory = solution_callback.output_directory
+	prefix = solution_callback.prefix
+	git_hash = solution_callback.git_hash
+
+	filenames = system_names(systems)
+
+	foreach_system(semi) do system
+		system_index = system_indices(system, semi)
+
+		trixi2json(system; system_name = filenames[system_index], output_directory, prefix, git_hash)
+	end
+end
+
+function trixi2json(system; system_name, output_directory, prefix, git_hash)
+	mkpath(output_directory)
+
+	meta_data = Dict{String, Any}(
+		"solver_version" => git_hash,
+		"julia_version" => string(VERSION),
+	)
+
+	get_meta_data!(meta_data, system)
+
+	# handle "_" on optional prefix strings
+	add_opt_str_pre(str) = (str === "" ? "" : "$(str)_")
+
+	# Write metadata to JSON-file
+	json_file = joinpath(output_directory,
+		add_opt_str_pre(prefix) * "$(system_name)_metadata.json")
+
+	open(json_file, "w") do file
+		JSON.print(file, meta_data, 2)
+	end
+end
+
+function get_meta_data!(meta_data, system::FluidSystem)
+	meta_data["acceleration"] = system.acceleration
+	meta_data["viscosity"] = type2string(system.viscosity)
+	get_meta_data!(meta_data, system.viscosity)
+	meta_data["smoothing_kernel"] = type2string(system.smoothing_kernel)
+	meta_data["smoothing_length"] = system.smoothing_length
+	meta_data["density_calculator"] = type2string(system.density_calculator)
+
+	if system isa WeaklyCompressibleSPHSystem
+		meta_data["state_equation"] = type2string(system.state_equation)
+		meta_data["state_equation_rho0"] = system.state_equation.reference_density
+		meta_data["state_equation_pa"] = system.state_equation.background_pressure
+		meta_data["state_equation_c"] = system.state_equation.sound_speed
+		meta_data["solver"] = "WCSPH"
+
+		meta_data["correction_method"] = type2string(system.correction)
+		if system.correction isa AkinciFreeSurfaceCorrection
+			meta_data["correction_rho0"] = system.correction.rho0
+		end
+		if system.state_equation isa StateEquationCole
+			meta_data["state_equation_exponent"] = system.state_equation.exponent
+		end
+		if system.state_equation isa StateEquationIdealGas
+			meta_data["state_equation_gamma"] = system.state_equation.gamma
+		end
+	else
+		meta_data["solver"] = "EDAC"
+		meta_data["sound_speed"] = system.sound_speed
+		meta_data["background_pressure_TVF"] = system.transport_velocity isa Nothing ? "-" :
+											   system.transport_velocity.background_pressure
+	end
+
+	return meta_data
+end
+
+get_meta_data!(meta_data, viscosity::Nothing) = meta_data
+
+function get_meta_data!(meta_data, viscosity::Union{ViscosityAdami, ViscosityMorris})
+	meta_data["viscosity_nu"] = viscosity.nu
+	meta_data["viscosity_epsilon"] = viscosity.epsilon
+end
+
+function get_meta_data!(meta_data, viscosity::ArtificialViscosityMonaghan)
+	meta_data["viscosity_alpha"] = viscosity.alpha
+	meta_data["viscosity_beta"] = viscosity.beta
+	meta_data["viscosity_epsilon"] = viscosity.epsilon
+end
+
+function get_meta_data!(meta_data, system::TotalLagrangianSPHSystem)
+	meta_data["young_modulus"] = system.young_modulus
+	meta_data["poisson_ratio"] = system.poisson_ratio
+	meta_data["lame_lambda"] = system.lame_lambda
+	meta_data["lame_mu"] = system.lame_mu
+	meta_data["smoothing_kernel"] = type2string(system.smoothing_kernel)
+	meta_data["smoothing_length"] = system.smoothing_length
+
+	get_meta_data!(meta_data, system.boundary_model, system)
+end
+
+function get_meta_data!(meta_data, system::OpenBoundarySPHSystem)
+	meta_data["boundary_zone"] = type2string(system.boundary_zone)
+	meta_data["width"] = round(system.boundary_zone.zone_width, digits = 3)
+	meta_data["flow_direction"] = system.flow_direction
+	meta_data["velocity_function"] = type2string(system.reference_velocity)
+	meta_data["pressure_function"] = type2string(system.reference_pressure)
+	meta_data["density_function"] = type2string(system.reference_density)
+end
+
+function get_meta_data!(meta_data, system::BoundarySPHSystem)
+	get_meta_data!(meta_data, system.boundary_model, system)
+end
+
+function get_meta_data!(meta_data, model, system)
+	return meta_data
+end
+
+function get_meta_data!(meta_data, model::BoundaryModelMonaghanKajtar, system)
+	meta_data["boundary_model"] = "BoundaryModelMonaghanKajtar"
+	meta_data["boundary_spacing_ratio"] = model.beta
+	meta_data["boundary_K"] = model.K
+end
+
+function get_meta_data!(meta_data, model::BoundaryModelDummyParticles, system)
+	meta_data["boundary_model"] = "BoundaryModelDummyParticles"
+	meta_data["smoothing_kernel"] = type2string(model.smoothing_kernel)
+	meta_data["smoothing_length"] = model.smoothing_length
+	meta_data["density_calculator"] = type2string(model.density_calculator)
+	meta_data["state_equation"] = type2string(model.state_equation)
+	meta_data["viscosity_model"] = type2string(model.viscosity)
+end
+
+function get_meta_data!(meta_data, system::BoundaryDEMSystem)
+	return meta_data
+end

--- a/src/visualization/write2vtk.jl
+++ b/src/visualization/write2vtk.jl
@@ -10,7 +10,7 @@ end
 
 """
     trixi2vtk(vu_ode, semi, t; iter=nothing, output_directory="out", prefix="",
-              write_meta_data=true, max_coordinates=Inf, custom_quantities...)
+              max_coordinates=Inf, custom_quantities...)
 
 Convert Trixi simulation data to VTK format.
 
@@ -25,7 +25,6 @@ Convert Trixi simulation data to VTK format.
                             separate files. This number is just appended to the filename.
 - `output_directory="out"`: Output directory path.
 - `prefix=""`:              Prefix for output files.
-- `write_meta_data=true`:   Write meta data.
 - `max_coordinates=Inf`     The coordinates of particles will be clipped if their absolute
                             values exceed this threshold.
 - `custom_quantities...`:   Additional custom quantities to include in the VTK output.
@@ -49,8 +48,7 @@ trixi2vtk(sol.u[end], semi, 0.0, iter=1, my_custom_quantity=kinetic_energy)
 ```
 """
 function trixi2vtk(vu_ode, semi, t; iter=nothing, output_directory="out", prefix="",
-                   write_meta_data=true, git_hash=compute_git_hash(),
-                   max_coordinates=Inf, custom_quantities...)
+                   git_hash=compute_git_hash(), max_coordinates=Inf, custom_quantities...)
     (; systems) = semi
     v_ode, u_ode = vu_ode.x
 
@@ -70,15 +68,14 @@ function trixi2vtk(vu_ode, semi, t; iter=nothing, output_directory="out", prefix
 
         trixi2vtk(v, u, t, system, periodic_box;
                   system_name=filenames[system_index], output_directory, iter, prefix,
-                  write_meta_data, git_hash, max_coordinates, custom_quantities...)
+                  git_hash, max_coordinates, custom_quantities...)
     end
 end
 
 # Convert data for a single TrixiParticle system to VTK format
 function trixi2vtk(v_, u_, t, system_, periodic_box; output_directory="out", prefix="",
-                   iter=nothing, system_name=vtkname(system_), write_meta_data=true,
-                   max_coordinates=Inf, git_hash=compute_git_hash(),
-                   custom_quantities...)
+                   iter=nothing, system_name=vtkname(system_), max_coordinates=Inf,
+                   git_hash=compute_git_hash(), custom_quantities...)
     mkpath(output_directory)
 
     # Skip empty systems
@@ -118,16 +115,11 @@ function trixi2vtk(v_, u_, t, system_, periodic_box; output_directory="out", pre
 
     @trixi_timeit timer() "write to vtk" vtk_grid(file, points, cells) do vtk
         # dispatches based on the different system types e.g. FluidSystem, TotalLagrangianSPHSystem
-        write2vtk!(vtk, v, u, t, system, write_meta_data=write_meta_data)
+        write2vtk!(vtk, v, u, t, system)
 
         # Store particle index
         vtk["index"] = active_particles(system)
         vtk["time"] = t
-
-        if write_meta_data
-            vtk["solver_version"] = git_hash
-            vtk["julia_version"] = string(VERSION)
-        end
 
         # Extract custom quantities for this system
         for (key, quantity) in custom_quantities
@@ -233,13 +225,13 @@ function trixi2vtk(initial_condition::InitialCondition; output_directory="out",
                      pressure=pressure, custom_quantities...)
 end
 
-function write2vtk!(vtk, v, u, t, system; write_meta_data=true)
+function write2vtk!(vtk, v, u, t, system)
     vtk["velocity"] = view(v, 1:ndims(system), :)
 
     return vtk
 end
 
-function write2vtk!(vtk, v, u, t, system::FluidSystem; write_meta_data=true)
+function write2vtk!(vtk, v, u, t, system::FluidSystem)
     vtk["velocity"] = [current_velocity(v, system, particle)
                        for particle in active_particles(system)]
     vtk["density"] = [particle_density(v, system, particle)
@@ -251,42 +243,6 @@ function write2vtk!(vtk, v, u, t, system::FluidSystem; write_meta_data=true)
         vtk["surf_normal"] = [surface_normal(system, particle)
                               for particle in eachparticle(system)]
         vtk["neighbor_count"] = system.cache.neighbor_count
-    end
-
-    if write_meta_data
-        vtk["acceleration"] = system.acceleration
-        vtk["viscosity"] = type2string(system.viscosity)
-        write2vtk!(vtk, system.viscosity)
-        vtk["smoothing_kernel"] = type2string(system.smoothing_kernel)
-        vtk["smoothing_length"] = system.smoothing_length
-        vtk["density_calculator"] = type2string(system.density_calculator)
-
-        if system isa WeaklyCompressibleSPHSystem
-            vtk["correction_method"] = type2string(system.correction)
-            if system.correction isa AkinciFreeSurfaceCorrection
-                vtk["correction_rho0"] = system.correction.rho0
-            end
-
-            if system.state_equation isa StateEquationCole
-                vtk["state_equation_exponent"] = system.state_equation.exponent
-            end
-
-            if system.state_equation isa StateEquationIdealGas
-                vtk["state_equation_gamma"] = system.state_equation.gamma
-            end
-
-            vtk["state_equation"] = type2string(system.state_equation)
-            vtk["state_equation_rho0"] = system.state_equation.reference_density
-            vtk["state_equation_pa"] = system.state_equation.background_pressure
-            vtk["state_equation_c"] = system.state_equation.sound_speed
-            vtk["solver"] = "WCSPH"
-        else
-            vtk["solver"] = "EDAC"
-            vtk["sound_speed"] = system.sound_speed
-            vtk["background_pressure_TVF"] = system.transport_velocity isa Nothing ?
-                                             "-" :
-                                             system.transport_velocity.background_pressure
-        end
     end
 
     return vtk
@@ -305,7 +261,7 @@ function write2vtk!(vtk, viscosity::ArtificialViscosityMonaghan)
     vtk["viscosity_epsilon"] = viscosity.epsilon
 end
 
-function write2vtk!(vtk, v, u, t, system::TotalLagrangianSPHSystem; write_meta_data=true)
+function write2vtk!(vtk, v, u, t, system::TotalLagrangianSPHSystem)
     n_fixed_particles = nparticles(system) - n_moving_particles(system)
 
     vtk["velocity"] = hcat(view(v, 1:ndims(system), :),
@@ -324,19 +280,10 @@ function write2vtk!(vtk, v, u, t, system::TotalLagrangianSPHSystem; write_meta_d
 
     vtk["material_density"] = system.material_density
 
-    if write_meta_data
-        vtk["young_modulus"] = system.young_modulus
-        vtk["poisson_ratio"] = system.poisson_ratio
-        vtk["lame_lambda"] = system.lame_lambda
-        vtk["lame_mu"] = system.lame_mu
-        vtk["smoothing_kernel"] = type2string(system.smoothing_kernel)
-        vtk["smoothing_length"] = system.smoothing_length
-    end
-
-    write2vtk!(vtk, v, u, t, system.boundary_model, system, write_meta_data=write_meta_data)
+    write2vtk!(vtk, v, u, t, system.boundary_model, system)
 end
 
-function write2vtk!(vtk, v, u, t, system::OpenBoundarySPHSystem; write_meta_data=true)
+function write2vtk!(vtk, v, u, t, system::OpenBoundarySPHSystem)
     vtk["velocity"] = [current_velocity(v, system, particle)
                        for particle in active_particles(system)]
     vtk["density"] = [particle_density(v, system, particle)
@@ -344,45 +291,22 @@ function write2vtk!(vtk, v, u, t, system::OpenBoundarySPHSystem; write_meta_data
     vtk["pressure"] = [particle_pressure(v, system, particle)
                        for particle in active_particles(system)]
 
-    if write_meta_data
-        vtk["boundary_zone"] = type2string(first(typeof(system.boundary_zone).parameters))
-        vtk["width"] = round(system.boundary_zone.zone_width, digits=3)
-        vtk["velocity_function"] = type2string(system.reference_velocity)
-        vtk["pressure_function"] = type2string(system.reference_pressure)
-        vtk["density_function"] = type2string(system.reference_density)
-    end
-
     return vtk
 end
 
-function write2vtk!(vtk, v, u, t, system::BoundarySPHSystem; write_meta_data=true)
-    write2vtk!(vtk, v, u, t, system.boundary_model, system, write_meta_data=write_meta_data)
+function write2vtk!(vtk, v, u, t, system::BoundarySPHSystem)
+    write2vtk!(vtk, v, u, t, system.boundary_model, system)
 end
 
-function write2vtk!(vtk, v, u, t, model, system; write_meta_data=true)
+function write2vtk!(vtk, v, u, t, model, system)
     return vtk
 end
 
-function write2vtk!(vtk, v, u, t, model::BoundaryModelMonaghanKajtar, system;
-                    write_meta_data=true)
-    if write_meta_data
-        vtk["boundary_model"] = "BoundaryModelMonaghanKajtar"
-        vtk["boundary_spacing_ratio"] = model.beta
-        vtk["boundary_K"] = model.K
-    end
+function write2vtk!(vtk, v, u, t, model::BoundaryModelMonaghanKajtar, system)
+    return vtk
 end
 
-function write2vtk!(vtk, v, u, t, model::BoundaryModelDummyParticles, system;
-                    write_meta_data=true)
-    if write_meta_data
-        vtk["boundary_model"] = "BoundaryModelDummyParticles"
-        vtk["smoothing_kernel"] = type2string(model.smoothing_kernel)
-        vtk["smoothing_length"] = model.smoothing_length
-        vtk["density_calculator"] = type2string(model.density_calculator)
-        vtk["state_equation"] = type2string(model.state_equation)
-        vtk["viscosity_model"] = type2string(model.viscosity)
-    end
-
+function write2vtk!(vtk, v, u, t, model::BoundaryModelDummyParticles, system)
     vtk["hydrodynamic_density"] = [particle_density(v, system, particle)
                                    for particle in eachparticle(system)]
     vtk["pressure"] = model.pressure
@@ -398,6 +322,6 @@ function write2vtk!(vtk, v, u, t, model::BoundaryModelDummyParticles, system;
     end
 end
 
-function write2vtk!(vtk, v, u, t, system::BoundaryDEMSystem; write_meta_data=true)
+function write2vtk!(vtk, v, u, t, system::BoundaryDEMSystem)
     return vtk
 end


### PR DESCRIPTION
This PR adds the new function `trixi2json`, which exports simulation metadata to a dedicated JSON file at the start of the simulation. Previously, metadata was stored within the VTK output files. The structure and design of `write2json.jl` closely follow the existing implementation in `write2vtk.jl` for consistency.

Remark: Tests for the new functionality will be added in a follow-up commit.