### PR TITLE
Remove unnecessary timers

### DIFF
--- a/src/callbacks/solution_saving.jl
+++ b/src/callbacks/solution_saving.jl
@@ -135,12 +135,6 @@ function initialize_save_cb!(solution_callback::SolutionSavingCallback, u, t, in
 
     # Save initial solution
     if solution_callback.save_initial_solution
-        # Update systems to compute quantities like density and pressure
-        semi = integrator.p
-        v_ode, u_ode = u.x
-        update_systems_and_nhs(v_ode, u_ode, semi, t; update_from_callback=true)
-
-        # Apply the callback
         solution_callback(integrator)
     end
 


### PR DESCRIPTION
Removes these timers cluttering the output. The update is also completely unnecessary, as it is right before the `affect!` is called, which updates again.
```diff
──────────────────────────────────────────────────────────────────────────────────────────
           TrixiParticles.jl                     Time                    Allocations      
                                        ───────────────────────   ────────────────────────
           Tot / % measured:                 3.65s /  46.6%            265MiB /  57.1%    

Section                         ncalls     time    %tot     avg     alloc    %tot      avg
──────────────────────────────────────────────────────────────────────────────────────────
save solution                       50    1.60s   93.9%  31.9ms    143MiB   94.3%  2.85MiB
  write to vtk                     100    1.23s   72.1%  12.3ms   98.0MiB   64.9%  0.98MiB
  ~save solution~                   50    369ms   21.7%  7.39ms   44.4MiB   29.3%   908KiB
  update systems                    50   1.16ms    0.1%  23.2μs    196KiB    0.1%  3.92KiB
    compute boundary pressure       50    540μs    0.0%  10.8μs   32.0KiB    0.0%     656B
    update nhs                      50    310μs    0.0%  6.20μs    141KiB    0.1%  2.81KiB
    inverse state equation          50    197μs    0.0%  3.94μs   12.5KiB    0.0%     256B
    ~update systems~                50    111μs    0.0%  2.21μs   10.9KiB    0.0%     224B
    update density diffusion        50    582ns    0.0%  11.6ns     0.00B    0.0%    0.00B
kick!                            1.11k   94.2ms    5.5%  84.7μs   6.57MiB    4.3%  6.05KiB
  system interaction             1.11k   64.8ms    3.8%  58.2μs   2.10MiB    1.4%  1.93KiB
    fluid1-fluid1                1.11k   48.1ms    2.8%  43.2μs    539KiB    0.3%     496B
    fluid1-boundary2             1.11k   15.0ms    0.9%  13.5μs    539KiB    0.3%     496B
    ~system interaction~         1.11k   1.69ms    0.1%  1.52μs   1.05MiB    0.7%     985B
    boundary2-boundary2          1.11k   12.5μs    0.0%  11.2ns     0.00B    0.0%    0.00B
    boundary2-fluid1             1.11k   12.0μs    0.0%  10.8ns     0.00B    0.0%    0.00B
  update systems and nhs         1.11k   24.2ms    1.4%  21.8μs   4.23MiB    2.8%  3.89KiB
    compute boundary pressure    1.11k   12.1ms    0.7%  10.8μs    713KiB    0.5%     656B
    update nhs                   1.11k   6.34ms    0.4%  5.70μs   3.06MiB    2.0%  2.81KiB
    inverse state equation       1.11k   3.13ms    0.2%  2.81μs    278KiB    0.2%     256B
    ~update systems and nhs~     1.11k   2.67ms    0.2%  2.40μs    210KiB    0.1%     193B
    update density diffusion     1.11k   11.7μs    0.0%  10.5ns     0.00B    0.0%    0.00B
  reset ∂v/∂t                    1.11k   3.43ms    0.2%  3.08μs     0.00B    0.0%    0.00B
  source terms                   1.11k   1.60ms    0.1%  1.43μs    243KiB    0.2%     224B
  ~kick!~                        1.11k    257μs    0.0%   231ns   1.55KiB    0.0%    1.42B
-update nhs                           1   6.79ms    0.4%  6.79ms   1.76MiB    1.2%  1.76MiB
drift!                           1.11k   1.86ms    0.1%  1.67μs    227KiB    0.1%     209B
  velocity                       1.11k   1.02ms    0.1%   920ns    226KiB    0.1%     208B
  reset ∂u/∂t                    1.11k    678μs    0.0%   609ns     0.00B    0.0%    0.00B
  ~drift!~                       1.11k    155μs    0.0%   139ns      976B    0.0%    0.88B
-compute boundary pressure            1   39.9μs    0.0%  39.9μs      656B    0.0%     656B
-inverse state equation               1   13.2μs    0.0%  13.2μs      256B    0.0%     256B
-update density diffusion             1   0.00ns    0.0%  0.00ns     0.00B    0.0%    0.00B
──────────────────────────────────────────────────────────────────────────────────────────
```