### PR TITLE
Use TrixiTest.jl

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -13,6 +13,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TrixiTest = "0a316866-cbd0-4425-8bcb-08103b2c1f26"
 
 [compat]
 CSV = "0.10"
@@ -25,3 +26,4 @@ OrdinaryDiffEq = "6.49"
 Plots = "1"
 Polyester = "0.7"
 QuadGK = "2"
+TrixiTest = "0.1"

--- a/test/examples/dam_break_2d_corrections.jl
+++ b/test/examples/dam_break_2d_corrections.jl
@@ -61,16 +61,17 @@
     )
 
     @testset "continuity_reinit" begin
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(examples_dir(), "fluid", "dam_break_2d.jl"),
-                                       fluid_particle_spacing=particle_spacing,
-                                       smoothing_length=1.5 * particle_spacing,
-                                       boundary_density_calculator=ContinuityDensity(),
-                                       fluid_density_calculator=ContinuityDensity(),
-                                       correction=nothing, use_reinit=true,
-                                       prefix="continuity_reinit", tspan=tspan,
-                                       fluid_density=fluid_density,
-                                       density_diffusion=nothing)
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(examples_dir(), "fluid",
+                                                  "dam_break_2d.jl"),
+                                         fluid_particle_spacing=particle_spacing,
+                                         smoothing_length=1.5 * particle_spacing,
+                                         boundary_density_calculator=ContinuityDensity(),
+                                         fluid_density_calculator=ContinuityDensity(),
+                                         correction=nothing, use_reinit=true,
+                                         prefix="continuity_reinit", tspan=tspan,
+                                         fluid_density=fluid_density,
+                                         density_diffusion=nothing)
 
         @test sol.retcode == ReturnCode.Success
         @test count_rhs_allocations(sol, semi) == 0
@@ -85,20 +86,21 @@
         println("="^100)
         println("fluid/dam_break_2d.jl with ", correction_name)
 
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(examples_dir(), "fluid", "dam_break_2d.jl"),
-                                       fluid_particle_spacing=particle_spacing,
-                                       smoothing_length=smoothing_length,
-                                       boundary_density_calculator=SummationDensity(),
-                                       fluid_density_calculator=fluid_density_calculator,
-                                       correction=correction, use_reinit=false,
-                                       clip_negative_pressure=(fluid_density_calculator isa
-                                                               SummationDensity),
-                                       smoothing_kernel=smoothing_kernel,
-                                       prefix="$(correction_name)", tspan=tspan,
-                                       fluid_density=fluid_density,
-                                       density_diffusion=nothing,
-                                       boundary_layers=5, sol=nothing)
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(examples_dir(), "fluid",
+                                                  "dam_break_2d.jl"),
+                                         fluid_particle_spacing=particle_spacing,
+                                         smoothing_length=smoothing_length,
+                                         boundary_density_calculator=SummationDensity(),
+                                         fluid_density_calculator=fluid_density_calculator,
+                                         correction=correction, use_reinit=false,
+                                         clip_negative_pressure=(fluid_density_calculator isa
+                                                                 SummationDensity),
+                                         smoothing_kernel=smoothing_kernel,
+                                         prefix="$(correction_name)", tspan=tspan,
+                                         fluid_density=fluid_density,
+                                         density_diffusion=nothing,
+                                         boundary_layers=5, sol=nothing)
 
         # Some correction methods require very small time steps at the beginning of the simulation.
         # An adaptive time integrator makes this easier and faster.

--- a/test/examples/examples.jl
+++ b/test/examples/examples.jl
@@ -5,10 +5,10 @@
 
     @testset verbose=true "Solid" begin
         @trixi_testset "solid/oscillating_beam_2d.jl" begin
-            @test_nowarn_mod trixi_include(@__MODULE__,
-                                           joinpath(examples_dir(), "solid",
-                                                    "oscillating_beam_2d.jl"),
-                                           tspan=(0.0, 0.1))
+            @trixi_test_nowarn trixi_include(@__MODULE__,
+                                             joinpath(examples_dir(), "solid",
+                                                      "oscillating_beam_2d.jl"),
+                                             tspan=(0.0, 0.1))
             @test sol.retcode == ReturnCode.Success
             @test count_rhs_allocations(sol, semi) == 0
         end
@@ -16,41 +16,41 @@
 
     @testset verbose=true "FSI" begin
         @trixi_testset "fsi/falling_water_column_2d.jl" begin
-            @test_nowarn_mod trixi_include(@__MODULE__,
-                                           joinpath(examples_dir(), "fsi",
-                                                    "falling_water_column_2d.jl"),
-                                           tspan=(0.0, 0.4))
+            @trixi_test_nowarn trixi_include(@__MODULE__,
+                                             joinpath(examples_dir(), "fsi",
+                                                      "falling_water_column_2d.jl"),
+                                             tspan=(0.0, 0.4))
             @test sol.retcode == ReturnCode.Success
             @test count_rhs_allocations(sol, semi) == 0
         end
 
         @trixi_testset "fsi/dam_break_plate_2d.jl" begin
             # Use rounded dimensions to avoid warnings
-            @test_nowarn_mod trixi_include(@__MODULE__,
-                                           joinpath(examples_dir(), "fsi",
-                                                    "dam_break_plate_2d.jl"),
-                                           initial_fluid_size=(0.15, 0.29),
-                                           tspan=(0.0, 0.4),
-                                           dtmax=1e-3)
+            @trixi_test_nowarn trixi_include(@__MODULE__,
+                                             joinpath(examples_dir(), "fsi",
+                                                      "dam_break_plate_2d.jl"),
+                                             initial_fluid_size=(0.15, 0.29),
+                                             tspan=(0.0, 0.4),
+                                             dtmax=1e-3)
             @test sol.retcode == ReturnCode.Success
             @test count_rhs_allocations(sol, semi) == 0
         end
 
         @trixi_testset "fsi/dam_break_gate_2d.jl" begin
-            @test_nowarn_mod trixi_include(@__MODULE__,
-                                           joinpath(examples_dir(), "fsi",
-                                                    "dam_break_gate_2d.jl"),
-                                           tspan=(0.0, 0.4),
-                                           dtmax=1e-3)
+            @trixi_test_nowarn trixi_include(@__MODULE__,
+                                             joinpath(examples_dir(), "fsi",
+                                                      "dam_break_gate_2d.jl"),
+                                             tspan=(0.0, 0.4),
+                                             dtmax=1e-3)
             @test sol.retcode == ReturnCode.Success
             @test count_rhs_allocations(sol, semi) == 0
         end
 
         @trixi_testset "fsi/falling_spheres_2d.jl" begin
-            @test_nowarn_mod trixi_include(@__MODULE__,
-                                           joinpath(examples_dir(), "fsi",
-                                                    "falling_spheres_2d.jl"),
-                                           tspan=(0.0, 1.0))
+            @trixi_test_nowarn trixi_include(@__MODULE__,
+                                             joinpath(examples_dir(), "fsi",
+                                                      "falling_spheres_2d.jl"),
+                                             tspan=(0.0, 1.0))
             @test sol.retcode == ReturnCode.Success
             @test count_rhs_allocations(sol, semi) == 0
         end
@@ -58,39 +58,39 @@
 
     @testset verbose=true "N-Body" begin
         @trixi_testset "n_body/n_body_solar_system.jl" begin
-            @test_nowarn_mod trixi_include(@__MODULE__,
-                                           joinpath(examples_dir(), "n_body",
-                                                    "n_body_solar_system.jl"))
+            @trixi_test_nowarn trixi_include(@__MODULE__,
+                                             joinpath(examples_dir(), "n_body",
+                                                      "n_body_solar_system.jl"))
             @test sol.retcode == ReturnCode.Success
             @test count_rhs_allocations(sol, semi) == 0
         end
 
         @trixi_testset "n_body/n_body_benchmark_trixi.jl" begin
-            @test_nowarn_mod trixi_include(@__MODULE__,
-                                           joinpath(examples_dir(), "n_body",
-                                                    "n_body_benchmark_trixi.jl")) [
+            @trixi_test_nowarn trixi_include(@__MODULE__,
+                                             joinpath(examples_dir(), "n_body",
+                                                      "n_body_benchmark_trixi.jl")) [
                 r"WARNING: Method definition interact!.*\n"
             ]
         end
 
         @trixi_testset "n_body/n_body_benchmark_reference.jl" begin
-            @test_nowarn_mod trixi_include(@__MODULE__,
-                                           joinpath(examples_dir(), "n_body",
-                                                    "n_body_benchmark_reference.jl"))
+            @trixi_test_nowarn trixi_include(@__MODULE__,
+                                             joinpath(examples_dir(), "n_body",
+                                                      "n_body_benchmark_reference.jl"))
         end
 
         @trixi_testset "n_body/n_body_benchmark_reference_faster.jl" begin
-            @test_nowarn_mod trixi_include(joinpath(examples_dir(), "n_body",
-                                                    "n_body_benchmark_reference_faster.jl"))
+            @trixi_test_nowarn trixi_include(joinpath(examples_dir(), "n_body",
+                                                      "n_body_benchmark_reference_faster.jl"))
         end
     end
 
     @testset verbose=true "Postprocessing" begin
         @trixi_testset "postprocessing/interpolation_plane.jl" begin
-            @test_nowarn_mod trixi_include(@__MODULE__,
-                                           joinpath(examples_dir(), "postprocessing",
-                                                    "interpolation_plane.jl"),
-                                           tspan=(0.0, 0.01)) [
+            @trixi_test_nowarn trixi_include(@__MODULE__,
+                                             joinpath(examples_dir(), "postprocessing",
+                                                      "interpolation_plane.jl"),
+                                             tspan=(0.0, 0.01)) [
                 r"WARNING: importing deprecated binding Makie.*\n",
                 r"WARNING: using deprecated binding Colors.*\n",
                 r"WARNING: using deprecated binding PlotUtils.*\n",
@@ -101,50 +101,51 @@
             @test sol.retcode == ReturnCode.Success
         end
         @trixi_testset "postprocessing/interpolation_point_line.jl" begin
-            @test_nowarn_mod trixi_include(@__MODULE__,
-                                           joinpath(examples_dir(), "postprocessing",
-                                                    "interpolation_point_line.jl"))
+            @trixi_test_nowarn trixi_include(@__MODULE__,
+                                             joinpath(examples_dir(), "postprocessing",
+                                                      "interpolation_point_line.jl"))
             @test sol.retcode == ReturnCode.Success
         end
         @trixi_testset "postprocessing/postprocessing.jl" begin
-            @test_nowarn_mod trixi_include(@__MODULE__,
-                                           joinpath(examples_dir(),
-                                                    "postprocessing",
-                                                    "postprocessing.jl"))
+            @trixi_test_nowarn trixi_include(@__MODULE__,
+                                             joinpath(examples_dir(),
+                                                      "postprocessing",
+                                                      "postprocessing.jl"))
             @test sol.retcode == ReturnCode.Success
         end
     end
 
     @testset verbose=true "Preprocessing" begin
         @trixi_testset "preprocessing/packing_2d.jl" begin
-            @test_nowarn_mod trixi_include(@__MODULE__,
-                                           joinpath(examples_dir(), "preprocessing",
-                                                    "packing_2d.jl"))
+            @trixi_test_nowarn trixi_include(@__MODULE__,
+                                             joinpath(examples_dir(), "preprocessing",
+                                                      "packing_2d.jl"))
             @test sol.retcode == ReturnCode.Terminated
         end
         @trixi_testset "preprocessing/packing_2d.jl validation" begin
-            @test_nowarn_mod trixi_include(@__MODULE__,
-                                           joinpath(examples_dir(), "preprocessing",
-                                                    "packing_2d.jl"), particle_spacing=0.4)
+            @trixi_test_nowarn trixi_include(@__MODULE__,
+                                             joinpath(examples_dir(), "preprocessing",
+                                                      "packing_2d.jl"),
+                                             particle_spacing=0.4)
             expected_coordinates = [-0.540548 -0.189943 0.191664 0.542741 -0.629391 -0.196159 0.197725 0.63081 -0.629447 -0.196158 0.19779 0.631121 -0.540483 -0.190015 0.191345 0.540433;
                                     -0.541127 -0.630201 -0.630119 -0.539294 -0.190697 -0.196942 -0.196916 -0.190324 0.190875 0.197074 0.196955 0.190973 0.541206 0.630323 0.630178 0.541314]
 
             @test isapprox(packed_ic.coordinates, expected_coordinates, atol=1e-5)
         end
         @trixi_testset "preprocessing/packing_3d.jl" begin
-            @test_nowarn_mod trixi_include(@__MODULE__,
-                                           joinpath(examples_dir(), "preprocessing",
-                                                    "packing_3d.jl"))
+            @trixi_test_nowarn trixi_include(@__MODULE__,
+                                             joinpath(examples_dir(), "preprocessing",
+                                                      "packing_3d.jl"))
         end
     end
 end
 
 @testset verbose=true "DEM" begin
     @trixi_testset "dem/rectangular_tank_2d.jl" begin
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(examples_dir(), "dem",
-                                                "rectangular_tank_2d.jl"),
-                                       tspan=(0.0, 0.1))
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(examples_dir(), "dem",
+                                                  "rectangular_tank_2d.jl"),
+                                         tspan=(0.0, 0.1))
         @test sol.retcode == ReturnCode.Success
         @test count_rhs_allocations(sol, semi) == 0
     end

--- a/test/examples/examples_fluid.jl
+++ b/test/examples/examples_fluid.jl
@@ -90,10 +90,10 @@
                 println("═"^100)
                 println("$test_description")
 
-                @test_nowarn_mod trixi_include(@__MODULE__,
-                                               joinpath(examples_dir(), "fluid",
-                                                        "hydrostatic_water_column_2d.jl");
-                                               kwargs...)
+                @trixi_test_nowarn trixi_include(@__MODULE__,
+                                                 joinpath(examples_dir(), "fluid",
+                                                          "hydrostatic_water_column_2d.jl");
+                                                 kwargs...)
 
                 @test sol.retcode == ReturnCode.Success
                 @test count_rhs_allocations(sol, semi) == 0
@@ -102,9 +102,9 @@
     end
 
     @trixi_testset "fluid/oscillating_drop_2d.jl" begin
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(examples_dir(), "fluid",
-                                                "oscillating_drop_2d.jl"))
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(examples_dir(), "fluid",
+                                                  "oscillating_drop_2d.jl"))
         @test sol.retcode == ReturnCode.Success
         # This error varies between serial and multithreaded runs
         @test isapprox(error_A, 0, atol=2e-4)
@@ -112,29 +112,29 @@
     end
 
     @trixi_testset "fluid/hydrostatic_water_column_3d.jl" begin
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(examples_dir(), "fluid",
-                                                "hydrostatic_water_column_3d.jl"),
-                                       tspan=(0.0, 0.1))
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(examples_dir(), "fluid",
+                                                  "hydrostatic_water_column_3d.jl"),
+                                         tspan=(0.0, 0.1))
         @test sol.retcode == ReturnCode.Success
         @test count_rhs_allocations(sol, semi) == 0
     end
 
     @trixi_testset "fluid/hydrostatic_water_column_3d.jl with SummationDensity" begin
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(examples_dir(), "fluid",
-                                                "hydrostatic_water_column_3d.jl"),
-                                       tspan=(0.0, 0.1),
-                                       fluid_density_calculator=SummationDensity(),
-                                       clip_negative_pressure=true)
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(examples_dir(), "fluid",
+                                                  "hydrostatic_water_column_3d.jl"),
+                                         tspan=(0.0, 0.1),
+                                         fluid_density_calculator=SummationDensity(),
+                                         clip_negative_pressure=true)
         @test sol.retcode == ReturnCode.Success
         @test count_rhs_allocations(sol, semi) == 0
     end
 
     @trixi_testset "fluid/accelerated_tank_2d.jl" begin
-        @test_nowarn_mod trixi_include(@__MODULE__, tspan=(0.0, 0.5),
-                                       joinpath(examples_dir(), "fluid",
-                                                "accelerated_tank_2d.jl"))
+        @trixi_test_nowarn trixi_include(@__MODULE__, tspan=(0.0, 0.5),
+                                         joinpath(examples_dir(), "fluid",
+                                                  "accelerated_tank_2d.jl"))
         @test sol.retcode == ReturnCode.Success
         @test count_rhs_allocations(sol, semi) == 0
     end
@@ -175,10 +175,10 @@
                 println("═"^100)
                 println("$test_description")
 
-                @test_nowarn_mod trixi_include(@__MODULE__,
-                                               joinpath(examples_dir(), "fluid",
-                                                        "dam_break_2d.jl");
-                                               tspan=(0, 0.1), kwargs...) [
+                @trixi_test_nowarn trixi_include(@__MODULE__,
+                                                 joinpath(examples_dir(), "fluid",
+                                                          "dam_break_2d.jl");
+                                                 tspan=(0, 0.1), kwargs...) [
                     r"┌ Info: The desired tank length in y-direction .*\n",
                     r"└ New tank length in y-direction.*\n"
                 ]
@@ -189,12 +189,12 @@
         end
 
         @testset "Float32" begin
-            @test_nowarn_mod trixi_include_changeprecision(Float32,
-                                                           @__MODULE__,
-                                                           joinpath(examples_dir(),
-                                                                    "fluid",
-                                                                    "dam_break_2d.jl"),
-                                                           tspan=(0, 0.1)) [
+            @trixi_test_nowarn trixi_include_changeprecision(Float32,
+                                                             @__MODULE__,
+                                                             joinpath(examples_dir(),
+                                                                      "fluid",
+                                                                      "dam_break_2d.jl"),
+                                                             tspan=(0, 0.1)) [
                 r"┌ Info: The desired tank length in y-direction .*\n",
                 r"└ New tank length in y-direction.*\n"
             ]
@@ -205,10 +205,10 @@
     end
 
     @trixi_testset "fluid/dam_break_2d_gpu.jl" begin
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(examples_dir(), "fluid",
-                                                "dam_break_2d_gpu.jl"),
-                                       tspan=(0.0, 0.1)) [
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(examples_dir(), "fluid",
+                                                  "dam_break_2d_gpu.jl"),
+                                         tspan=(0.0, 0.1)) [
             r"┌ Info: The desired tank length in y-direction .*\n",
             r"└ New tank length in y-direction.*\n"
         ]
@@ -218,10 +218,10 @@
     end
 
     @trixi_testset "fluid/dam_break_oil_film_2d.jl" begin
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(examples_dir(), "fluid",
-                                                "dam_break_oil_film_2d.jl"),
-                                       tspan=(0.0, 0.05)) [
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(examples_dir(), "fluid",
+                                                  "dam_break_oil_film_2d.jl"),
+                                         tspan=(0.0, 0.05)) [
             r"┌ Info: The desired tank length in y-direction .*\n",
             r"└ New tank length in y-direction.*\n"
         ]
@@ -230,10 +230,10 @@
     end
 
     @trixi_testset "fluid/dam_break_2phase_2d.jl" begin
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(examples_dir(), "fluid",
-                                                "dam_break_2phase_2d.jl"),
-                                       tspan=(0.0, 0.05)) [
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(examples_dir(), "fluid",
+                                                  "dam_break_2phase_2d.jl"),
+                                         tspan=(0.0, 0.05)) [
             r"┌ Info: The desired tank length in y-direction .*\n",
             r"└ New tank length in y-direction.*\n"
         ]
@@ -242,76 +242,76 @@
     end
 
     @trixi_testset "fluid/dam_break_3d.jl" begin
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(examples_dir(), "fluid",
-                                                "dam_break_3d.jl"),
-                                       tspan=(0.0, 0.1), fluid_particle_spacing=0.1)
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(examples_dir(), "fluid",
+                                                  "dam_break_3d.jl"),
+                                         tspan=(0.0, 0.1), fluid_particle_spacing=0.1)
         @test sol.retcode == ReturnCode.Success
         @test count_rhs_allocations(sol, semi) == 0
     end
 
     @trixi_testset "fluid/falling_water_column_2d.jl" begin
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(examples_dir(), "fluid",
-                                                "falling_water_column_2d.jl"),
-                                       tspan=(0.0, 0.4))
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(examples_dir(), "fluid",
+                                                  "falling_water_column_2d.jl"),
+                                         tspan=(0.0, 0.4))
         @test sol.retcode == ReturnCode.Success
         @test count_rhs_allocations(sol, semi) == 0
     end
 
     @trixi_testset "fluid/periodic_channel_2d.jl" begin
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(examples_dir(), "fluid",
-                                                "periodic_channel_2d.jl"),
-                                       tspan=(0.0, 0.4))
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(examples_dir(), "fluid",
+                                                  "periodic_channel_2d.jl"),
+                                         tspan=(0.0, 0.4))
         @test sol.retcode == ReturnCode.Success
         @test count_rhs_allocations(sol, semi) == 0
     end
 
     @trixi_testset "fluid/pipe_flow_2d.jl - BoundaryModelLastiwka (WCSPH)" begin
-        @test_nowarn_mod trixi_include(@__MODULE__, tspan=(0.0, 0.5),
-                                       joinpath(examples_dir(), "fluid",
-                                                "pipe_flow_2d.jl"),
-                                       wcsph=true)
+        @trixi_test_nowarn trixi_include(@__MODULE__, tspan=(0.0, 0.5),
+                                         joinpath(examples_dir(), "fluid",
+                                                  "pipe_flow_2d.jl"),
+                                         wcsph=true)
         @test sol.retcode == ReturnCode.Success
         @test count_rhs_allocations(sol, semi) == 0
     end
 
     @trixi_testset "fluid/pipe_flow_2d.jl - BoundaryModelLastiwka (EDAC)" begin
-        @test_nowarn_mod trixi_include(@__MODULE__, tspan=(0.0, 0.5),
-                                       joinpath(examples_dir(), "fluid",
-                                                "pipe_flow_2d.jl"))
+        @trixi_test_nowarn trixi_include(@__MODULE__, tspan=(0.0, 0.5),
+                                         joinpath(examples_dir(), "fluid",
+                                                  "pipe_flow_2d.jl"))
         @test sol.retcode == ReturnCode.Success
         @test count_rhs_allocations(sol, semi) == 0
     end
 
     @trixi_testset "fluid/pipe_flow_2d.jl - BoundaryModelTafuni (EDAC)" begin
-        @test_nowarn_mod trixi_include(@__MODULE__, tspan=(0.0, 0.5),
-                                       joinpath(examples_dir(), "fluid",
-                                                "pipe_flow_2d.jl"),
-                                       open_boundary_model=BoundaryModelTafuni(),
-                                       boundary_type_in=BidirectionalFlow(),
-                                       boundary_type_out=BidirectionalFlow(),
-                                       reference_density_in=nothing,
-                                       reference_pressure_in=nothing,
-                                       reference_density_out=nothing,
-                                       reference_velocity_out=nothing)
+        @trixi_test_nowarn trixi_include(@__MODULE__, tspan=(0.0, 0.5),
+                                         joinpath(examples_dir(), "fluid",
+                                                  "pipe_flow_2d.jl"),
+                                         open_boundary_model=BoundaryModelTafuni(),
+                                         boundary_type_in=BidirectionalFlow(),
+                                         boundary_type_out=BidirectionalFlow(),
+                                         reference_density_in=nothing,
+                                         reference_pressure_in=nothing,
+                                         reference_density_out=nothing,
+                                         reference_velocity_out=nothing)
         @test sol.retcode == ReturnCode.Success
         @test count_rhs_allocations(sol, semi) == 0
     end
 
     @trixi_testset "fluid/pipe_flow_2d.jl - BoundaryModelTafuni (WCSPH)" begin
-        @test_nowarn_mod trixi_include(@__MODULE__, tspan=(0.0, 0.5),
-                                       joinpath(examples_dir(), "fluid",
-                                                "pipe_flow_2d.jl"),
-                                       wcsph=true, sound_speed=20.0, pressure=0.0,
-                                       open_boundary_model=BoundaryModelTafuni(),
-                                       boundary_type_in=BidirectionalFlow(),
-                                       boundary_type_out=BidirectionalFlow(),
-                                       reference_density_in=nothing,
-                                       reference_pressure_in=nothing,
-                                       reference_density_out=nothing,
-                                       reference_velocity_out=nothing)
+        @trixi_test_nowarn trixi_include(@__MODULE__, tspan=(0.0, 0.5),
+                                         joinpath(examples_dir(), "fluid",
+                                                  "pipe_flow_2d.jl"),
+                                         wcsph=true, sound_speed=20.0, pressure=0.0,
+                                         open_boundary_model=BoundaryModelTafuni(),
+                                         boundary_type_in=BidirectionalFlow(),
+                                         boundary_type_out=BidirectionalFlow(),
+                                         reference_density_in=nothing,
+                                         reference_pressure_in=nothing,
+                                         reference_density_out=nothing,
+                                         reference_velocity_out=nothing)
         @test sol.retcode == ReturnCode.Success
         @test count_rhs_allocations(sol, semi) == 0
     end
@@ -319,11 +319,11 @@
     @trixi_testset "fluid/pipe_flow_2d.jl - steady state reached (`dt`)" begin
         steady_state_reached = SteadyStateReachedCallback(; dt=0.002, interval_size=10)
 
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(examples_dir(), "fluid",
-                                                "pipe_flow_2d.jl"),
-                                       extra_callback=steady_state_reached,
-                                       tspan=(0.0, 1.5), viscosity_boundary=nothing)
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(examples_dir(), "fluid",
+                                                  "pipe_flow_2d.jl"),
+                                         extra_callback=steady_state_reached,
+                                         tspan=(0.0, 1.5), viscosity_boundary=nothing)
 
         # Make sure that the simulation is terminated after a reasonable amount of time
         @test 0.1 < sol.t[end] < 1.0
@@ -334,11 +334,11 @@
         steady_state_reached = SteadyStateReachedCallback(; interval=1,
                                                           interval_size=10,
                                                           abstol=1.0e-5, reltol=1.0e-4)
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(examples_dir(), "fluid",
-                                                "pipe_flow_2d.jl"),
-                                       extra_callback=steady_state_reached,
-                                       tspan=(0.0, 1.5), viscosity_boundary=nothing)
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(examples_dir(), "fluid",
+                                                  "pipe_flow_2d.jl"),
+                                         extra_callback=steady_state_reached,
+                                         tspan=(0.0, 1.5), viscosity_boundary=nothing)
 
         # Make sure that the simulation is terminated after a reasonable amount of time
         @test 0.1 < sol.t[end] < 1.0
@@ -346,70 +346,70 @@
     end
 
     @trixi_testset "fluid/pipe_flow_3d.jl" begin
-        @test_nowarn_mod trixi_include(@__MODULE__, tspan=(0.0, 0.5),
-                                       joinpath(examples_dir(), "fluid",
-                                                "pipe_flow_3d.jl"))
+        @trixi_test_nowarn trixi_include(@__MODULE__, tspan=(0.0, 0.5),
+                                         joinpath(examples_dir(), "fluid",
+                                                  "pipe_flow_3d.jl"))
         @test sol.retcode == ReturnCode.Success
         @test count_rhs_allocations(sol, semi) == 0
     end
 
     @trixi_testset "fluid/lid_driven_cavity_2d.jl (EDAC)" begin
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(examples_dir(), "fluid",
-                                                "lid_driven_cavity_2d.jl"),
-                                       tspan=(0.0, 0.1))
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(examples_dir(), "fluid",
+                                                  "lid_driven_cavity_2d.jl"),
+                                         tspan=(0.0, 0.1))
         @test sol.retcode == ReturnCode.Success
         @test count_rhs_allocations(sol, semi) == 0
     end
 
     @trixi_testset "fluid/lid_driven_cavity_2d.jl (WCSPH)" begin
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(examples_dir(), "fluid",
-                                                "lid_driven_cavity_2d.jl"),
-                                       tspan=(0.0, 0.1), wcsph=true)
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(examples_dir(), "fluid",
+                                                  "lid_driven_cavity_2d.jl"),
+                                         tspan=(0.0, 0.1), wcsph=true)
         @test sol.retcode == ReturnCode.Success
         @test count_rhs_allocations(sol, semi) == 0
     end
 
     @trixi_testset "fluid/taylor_green_vortex_2d.jl (EDAC)" begin
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(examples_dir(), "fluid",
-                                                "taylor_green_vortex_2d.jl"),
-                                       tspan=(0.0, 0.1))
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(examples_dir(), "fluid",
+                                                  "taylor_green_vortex_2d.jl"),
+                                         tspan=(0.0, 0.1))
         @test sol.retcode == ReturnCode.Success
         @test count_rhs_allocations(sol, semi) == 0
     end
 
     @trixi_testset "fluid/taylor_green_vortex_2d.jl (WCSPH)" begin
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(examples_dir(), "fluid",
-                                                "taylor_green_vortex_2d.jl"),
-                                       tspan=(0.0, 0.1), wcsph=true)
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(examples_dir(), "fluid",
+                                                  "taylor_green_vortex_2d.jl"),
+                                         tspan=(0.0, 0.1), wcsph=true)
         @test sol.retcode == ReturnCode.Success
         @test count_rhs_allocations(sol, semi) == 0
     end
 
     @trixi_testset "fluid/sphere_surface_tension_2d.jl" begin
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(examples_dir(), "fluid",
-                                                "sphere_surface_tension_2d.jl"))
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(examples_dir(), "fluid",
+                                                  "sphere_surface_tension_2d.jl"))
         @test sol.retcode == ReturnCode.Success
         @test count_rhs_allocations(sol, semi) == 0
     end
 
     @trixi_testset "fluid/periodic_array_of_cylinders_2d.jl" begin
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(examples_dir(), "fluid",
-                                                "periodic_array_of_cylinders_2d.jl"),
-                                       tspan=(0.0, 0.1))
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(examples_dir(), "fluid",
+                                                  "periodic_array_of_cylinders_2d.jl"),
+                                         tspan=(0.0, 0.1))
         @test sol.retcode == ReturnCode.Success
         @test count_rhs_allocations(sol, semi) == 0
     end
 
     @trixi_testset "fluid/sphere_surface_tension_3d.jl" begin
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(examples_dir(), "fluid",
-                                                "sphere_surface_tension_3d.jl"))
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(examples_dir(), "fluid",
+                                                  "sphere_surface_tension_3d.jl"))
         @test sol.retcode == ReturnCode.Success
         @test count_rhs_allocations(sol, semi) == 0
     end
@@ -433,10 +433,10 @@
                          (surface_tension=surface_tension,)
 
                 # Execute the example script with the current surface tension model
-                @test_nowarn_mod trixi_include(@__MODULE__,
-                                               joinpath(examples_dir(), "fluid",
-                                                        "falling_water_spheres_2d.jl");
-                                               tspan=(0, 0.1), kwargs...)
+                @trixi_test_nowarn trixi_include(@__MODULE__,
+                                                 joinpath(examples_dir(), "fluid",
+                                                          "falling_water_spheres_2d.jl");
+                                                 tspan=(0, 0.1), kwargs...)
 
                 # Assert that the simulation ran successfully
                 @test sol.retcode == ReturnCode.Success
@@ -466,11 +466,12 @@
                          (surface_tension=surface_tension,)
 
                 # Execute the example script with the current surface tension model
-                @test_nowarn_mod trixi_include(@__MODULE__,
-                                               joinpath(examples_dir(), "fluid",
-                                                        "falling_water_spheres_3d.jl");
-                                               tspan=(0, 0.05), fluid_particle_spacing=0.01,
-                                               kwargs...) [
+                @trixi_test_nowarn trixi_include(@__MODULE__,
+                                                 joinpath(examples_dir(), "fluid",
+                                                          "falling_water_spheres_3d.jl");
+                                                 tspan=(0, 0.05),
+                                                 fluid_particle_spacing=0.01,
+                                                 kwargs...) [
                     # Optional: Add regex patterns to ignore specific warnings or logs
                     r"┌ Info: The desired tank length in x-direction .*\n",
                     r"└ New tank length in x-direction.*\n",
@@ -490,15 +491,15 @@
     end
 
     @trixi_testset "fluid/sphere_surface_tension_wall_2d.jl" begin
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(examples_dir(), "fluid",
-                                                "sphere_surface_tension_wall_2d.jl"))
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(examples_dir(), "fluid",
+                                                  "sphere_surface_tension_wall_2d.jl"))
     end
 
     @trixi_testset "fluid/moving_wall_2d.jl" begin
-        @test_nowarn_mod trixi_include(@__MODULE__, tspan=(0.0, 0.5),
-                                       joinpath(examples_dir(), "fluid",
-                                                "moving_wall_2d.jl"))
+        @trixi_test_nowarn trixi_include(@__MODULE__, tspan=(0.0, 0.5),
+                                         joinpath(examples_dir(), "fluid",
+                                                  "moving_wall_2d.jl"))
         @test sol.retcode == ReturnCode.Success
         @test count_rhs_allocations(sol, semi) == 0
     end
@@ -507,10 +508,10 @@
 
     @testset "`SymplecticPositionVerlet`" begin
         @testset "2D unstable" begin
-            @test_nowarn_mod trixi_include(@__MODULE__,
-                                           joinpath(examples_dir(), "fluid",
-                                                    "dam_break_2d.jl"),
-                                           tspan=(0, 0.1), sol=nothing) [
+            @trixi_test_nowarn trixi_include(@__MODULE__,
+                                             joinpath(examples_dir(), "fluid",
+                                                      "dam_break_2d.jl"),
+                                             tspan=(0, 0.1), sol=nothing) [
                 r"┌ Info: The desired tank length in y-direction .*\n",
                 r"└ New tank length in y-direction.*\n"]
 
@@ -525,11 +526,11 @@
         end
 
         @testset "2D stable" begin
-            @test_nowarn_mod trixi_include(@__MODULE__,
-                                           joinpath(examples_dir(), "fluid",
-                                                    "dam_break_2d.jl"),
-                                           tspan=(0, 0.1), sol=nothing,
-                                           cfl=0.25) [
+            @trixi_test_nowarn trixi_include(@__MODULE__,
+                                             joinpath(examples_dir(), "fluid",
+                                                      "dam_break_2d.jl"),
+                                             tspan=(0, 0.1), sol=nothing,
+                                             cfl=0.25) [
                 r"┌ Info: The desired tank length in y-direction .*\n",
                 r"└ New tank length in y-direction.*\n"]
 
@@ -544,11 +545,11 @@
         end
 
         @testset "3D" begin
-            @test_nowarn_mod trixi_include(@__MODULE__,
-                                           joinpath(examples_dir(), "fluid",
-                                                    "dam_break_3d.jl"),
-                                           fluid_particle_spacing=0.1,
-                                           tspan=(0, 0.1), sol=nothing)
+            @trixi_test_nowarn trixi_include(@__MODULE__,
+                                             joinpath(examples_dir(), "fluid",
+                                                      "dam_break_3d.jl"),
+                                             fluid_particle_spacing=0.1,
+                                             tspan=(0, 0.1), sol=nothing)
             stepsize_callback = StepsizeCallback(cfl=0.65)
             callbacks = CallbackSet(info_callback, saving_callback, stepsize_callback)
 

--- a/test/examples/gpu.jl
+++ b/test/examples/gpu.jl
@@ -29,11 +29,11 @@ end
     @testset verbose=true "Fluid" begin
         @trixi_testset "fluid/dam_break_2d_gpu.jl Float64" begin
             if Main.supports_double_precision
-                @test_nowarn_mod trixi_include(@__MODULE__,
-                                               joinpath(examples_dir(), "fluid",
-                                                        "dam_break_2d_gpu.jl"),
-                                               tspan=(0.0, 0.1),
-                                               parallelization_backend=Main.parallelization_backend) [
+                @trixi_test_nowarn trixi_include(@__MODULE__,
+                                                 joinpath(examples_dir(), "fluid",
+                                                          "dam_break_2d_gpu.jl"),
+                                                 tspan=(0.0, 0.1),
+                                                 parallelization_backend=Main.parallelization_backend) [
                     r"┌ Info: The desired tank length in y-direction .*\n",
                     r"└ New tank length in y-direction.*\n"
                 ]
@@ -69,13 +69,13 @@ end
                     println("═"^100)
                     println("$test_description")
 
-                    @test_nowarn_mod trixi_include_changeprecision(Float32, @__MODULE__,
-                                                                   joinpath(examples_dir(),
-                                                                            "fluid",
-                                                                            "dam_break_2d_gpu.jl");
-                                                                   tspan=(0.0f0, 0.1f0),
-                                                                   parallelization_backend=Main.parallelization_backend,
-                                                                   kwargs...) [
+                    @trixi_test_nowarn trixi_include_changeprecision(Float32, @__MODULE__,
+                                                                     joinpath(examples_dir(),
+                                                                              "fluid",
+                                                                              "dam_break_2d_gpu.jl");
+                                                                     tspan=(0.0f0, 0.1f0),
+                                                                     parallelization_backend=Main.parallelization_backend,
+                                                                     kwargs...) [
                         r"┌ Info: The desired tank length in y-direction .*\n",
                         r"└ New tank length in y-direction.*\n"
                     ]
@@ -100,15 +100,15 @@ end
                                                          boundary_particle_spacing,
                                                          tank.boundary.mass)
 
-            @test_nowarn_mod trixi_include_changeprecision(Float32, @__MODULE__,
-                                                           joinpath(examples_dir(),
-                                                                    "fluid",
-                                                                    "dam_break_2d_gpu.jl");
-                                                           tspan=(0.0f0, 0.1f0),
-                                                           boundary_layers=1,
-                                                           spacing_ratio=3,
-                                                           boundary_model=boundary_model,
-                                                           parallelization_backend=Main.parallelization_backend) [
+            @trixi_test_nowarn trixi_include_changeprecision(Float32, @__MODULE__,
+                                                             joinpath(examples_dir(),
+                                                                      "fluid",
+                                                                      "dam_break_2d_gpu.jl");
+                                                             tspan=(0.0f0, 0.1f0),
+                                                             boundary_layers=1,
+                                                             spacing_ratio=3,
+                                                             boundary_model=boundary_model,
+                                                             parallelization_backend=Main.parallelization_backend) [
                 r"┌ Info: The desired tank length in y-direction .*\n",
                 r"└ New tank length in y-direction.*\n"
             ]
@@ -241,13 +241,13 @@ end
                                                        parallelization_backend=Main.parallelization_backend)
 
                     # Run the simulation
-                    @test_nowarn_mod trixi_include_changeprecision(Float32, @__MODULE__,
-                                                                   joinpath(examples_dir(),
-                                                                            "fluid",
-                                                                            "hydrostatic_water_column_2d.jl");
-                                                                   semi=semi_fullgrid,
-                                                                   tspan=(0.0f0, 0.1f0),
-                                                                   kwargs...)
+                    @trixi_test_nowarn trixi_include_changeprecision(Float32, @__MODULE__,
+                                                                     joinpath(examples_dir(),
+                                                                              "fluid",
+                                                                              "hydrostatic_water_column_2d.jl");
+                                                                     semi=semi_fullgrid,
+                                                                     tspan=(0.0f0, 0.1f0),
+                                                                     kwargs...)
 
                     @test sol.retcode == ReturnCode.Success
                     backend = TrixiParticles.KernelAbstractions.get_backend(sol.u[end].x[1])
@@ -275,11 +275,12 @@ end
                                                                                              cell_list),
                                                parallelization_backend=Main.parallelization_backend)
 
-            @test_nowarn_mod trixi_include_changeprecision(Float32, @__MODULE__,
-                                                           joinpath(examples_dir(), "fluid",
-                                                                    "periodic_channel_2d.jl"),
-                                                           tspan=(0.0f0, 0.1f0),
-                                                           semi=semi_fullgrid)
+            @trixi_test_nowarn trixi_include_changeprecision(Float32, @__MODULE__,
+                                                             joinpath(examples_dir(),
+                                                                      "fluid",
+                                                                      "periodic_channel_2d.jl"),
+                                                             tspan=(0.0f0, 0.1f0),
+                                                             semi=semi_fullgrid)
             @test sol.retcode == ReturnCode.Success
             backend = TrixiParticles.KernelAbstractions.get_backend(sol.u[end].x[1])
             @test backend == Main.parallelization_backend
@@ -307,7 +308,7 @@ end
 
             # steady_state_reached = SteadyStateReachedCallback(; dt=0.002, interval_size=10)
 
-            # @test_nowarn_mod trixi_include_changeprecision(Float32, @__MODULE__,
+            # @trixi_test_nowarn trixi_include_changeprecision(Float32, @__MODULE__,
             #                                                joinpath(examples_dir(), "fluid",
             #                                                         "pipe_flow_2d.jl"),
             #                                                extra_callback=steady_state_reached,
@@ -344,11 +345,12 @@ end
                                                                                              cell_list),
                                                parallelization_backend=Main.parallelization_backend)
 
-            @test_nowarn_mod trixi_include_changeprecision(Float32, @__MODULE__,
-                                                           joinpath(examples_dir(), "solid",
-                                                                    "oscillating_beam_2d.jl"),
-                                                           tspan=(0.0f0, 0.1f0),
-                                                           semi=semi_fullgrid)
+            @trixi_test_nowarn trixi_include_changeprecision(Float32, @__MODULE__,
+                                                             joinpath(examples_dir(),
+                                                                      "solid",
+                                                                      "oscillating_beam_2d.jl"),
+                                                             tspan=(0.0f0, 0.1f0),
+                                                             semi=semi_fullgrid)
             @test sol.retcode == ReturnCode.Success
             backend = TrixiParticles.KernelAbstractions.get_backend(sol.u[end].x[1])
             @test backend == Main.parallelization_backend
@@ -376,13 +378,13 @@ end
                                                                                              cell_list),
                                                parallelization_backend=Main.parallelization_backend)
 
-            @test_nowarn_mod trixi_include_changeprecision(Float32, @__MODULE__,
-                                                           joinpath(examples_dir(), "fsi",
-                                                                    "dam_break_gate_2d.jl"),
-                                                           tspan=(0.0f0, 0.4f0),
-                                                           semi=semi_fullgrid,
-                                                           # Needs <1500 steps on the CPU
-                                                           maxiters=1500)
+            @trixi_test_nowarn trixi_include_changeprecision(Float32, @__MODULE__,
+                                                             joinpath(examples_dir(), "fsi",
+                                                                      "dam_break_gate_2d.jl"),
+                                                             tspan=(0.0f0, 0.4f0),
+                                                             semi=semi_fullgrid,
+                                                             # Needs <1500 steps on the CPU
+                                                             maxiters=1500)
             @test sol.retcode == ReturnCode.Success
             backend = TrixiParticles.KernelAbstractions.get_backend(sol.u[end].x[1])
             @test backend == Main.parallelization_backend

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -1,4 +1,5 @@
 using Test
+using TrixiTest: @trixi_test_nowarn
 using TrixiParticles
 using TrixiParticles: PointNeighbors
 using LinearAlgebra
@@ -32,7 +33,7 @@ macro trixi_testset(name, expr)
 
         # We also include this file again to provide the definition of
         # the other testing macros. This allows to use `@trixi_testset`
-        # in a nested fashion and also call `@test_nowarn_mod` from
+        # in a nested fashion and also call `@trixi_test_nowarn` from
         # there.
         include(@__FILE__)
 
@@ -40,49 +41,6 @@ macro trixi_testset(name, expr)
         end
 
         nothing
-    end
-end
-
-# Copied from TrixiBase.jl. See https://github.com/trixi-framework/TrixiBase.jl/issues/9.
-"""
-    @test_nowarn_mod expr
-
-Modified version of `@test_nowarn expr` that prints the content of `stderr` when
-it is not empty and ignores some common info statements printed in Trixi.jl
-uses.
-"""
-macro test_nowarn_mod(expr, additional_ignore_content=String[])
-    quote
-        let fname = tempname()
-            try
-                ret = open(fname, "w") do f
-                    redirect_stderr(f) do
-                        $(esc(expr))
-                    end
-                end
-                stderr_content = read(fname, String)
-                if !isempty(stderr_content)
-                    println("Content of `stderr`:\n", stderr_content)
-                end
-
-                # Patterns matching the following ones will be ignored. Additional patterns
-                # passed as arguments can also be regular expressions, so we just use the
-                # type `Any` for `ignore_content`.
-                ignore_content = Any["[ Info: You just called `trixi_include`. Julia may now compile the code, please be patient.\n"]
-                append!(ignore_content, $additional_ignore_content)
-                for pattern in ignore_content
-                    stderr_content = replace(stderr_content, pattern => "")
-                end
-
-                # We also ignore simple module redefinitions for convenience. Thus, we
-                # check whether every line of `stderr_content` is of the form of a
-                # module replacement warning.
-                @test occursin(r"^(WARNING: replacing module .+\.\n)*$", stderr_content)
-                ret
-            finally
-                rm(fname, force=true)
-            end
-        end
     end
 end
 

--- a/test/validation/validation.jl
+++ b/test/validation/validation.jl
@@ -1,9 +1,9 @@
 @testset verbose=true "Validation" begin
     @trixi_testset "general" begin
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(validation_dir(), "general",
-                                                "investigate_relaxation.jl"),
-                                       tspan=(0.0, 1.0))
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(validation_dir(), "general",
+                                                  "investigate_relaxation.jl"),
+                                         tspan=(0.0, 1.0))
         @test sol.retcode == ReturnCode.Success
         @test count_rhs_allocations(sol, semi) == 0
         # Verify number of plots
@@ -11,19 +11,19 @@
     end
 
     @trixi_testset "oscillating_beam_2d" begin
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(validation_dir(), "oscillating_beam_2d",
-                                                "validation_oscillating_beam_2d.jl"),
-                                       tspan=(0.0, 1.0))
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(validation_dir(), "oscillating_beam_2d",
+                                                  "validation_oscillating_beam_2d.jl"),
+                                         tspan=(0.0, 1.0))
         @test sol.retcode == ReturnCode.Success
         @test count_rhs_allocations(sol, semi) == 0
         @test isapprox(error_deflection_x, 0, atol=eps())
         @test isapprox(error_deflection_y, 0, atol=eps())
 
         # Ignore method redefinitions from duplicate `include("../validation_util.jl")`
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(validation_dir(), "oscillating_beam_2d",
-                                                "plot_oscillating_beam_results.jl")) [
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(validation_dir(), "oscillating_beam_2d",
+                                                  "plot_oscillating_beam_results.jl")) [
             r"WARNING: Method definition linear_interpolation.*\n",
             r"WARNING: Method definition interpolated_mse.*\n",
             r"WARNING: Method definition extract_number_from_filename.*\n",
@@ -38,9 +38,9 @@
     end
 
     @trixi_testset "dam_break_2d" begin
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(validation_dir(), "dam_break_2d",
-                                                "validation_dam_break_2d.jl")) [
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(validation_dir(), "dam_break_2d",
+                                                  "validation_dam_break_2d.jl")) [
             r"┌ Info: The desired tank length in y-direction.*\n",
             r"└ New tank length in y-direction is set to.*\n"
         ]
@@ -72,9 +72,9 @@
         end
 
         # Ignore method redefinitions from duplicate `include("../validation_util.jl")`
-        @test_nowarn_mod trixi_include(@__MODULE__,
-                                       joinpath(validation_dir(), "dam_break_2d",
-                                                "plot_dam_break_results.jl")) [
+        @trixi_test_nowarn trixi_include(@__MODULE__,
+                                         joinpath(validation_dir(), "dam_break_2d",
+                                                  "plot_dam_break_results.jl")) [
             r"WARNING: Method definition linear_interpolation.*\n",
             r"WARNING: Method definition interpolated_mse.*\n",
             r"WARNING: Method definition extract_number_from_filename.*\n",


### PR DESCRIPTION
We have created a new package [TrixiTest.jl](https://github.com/trixi-framework/TrixiTest.jl), which defines the macro `@test_nowarn_mod` but renamed to `@trixi_test_nowarn`. For consistency, avoiding unnecessary redundancy, and simplified maintenance, this PR uses the macro from TrixiTest.jl and deletes it from this repo. See, e.g., also the corresponding PR in Trixi.jl: https://github.com/trixi-framework/Trixi.jl/pull/2395.