### PR TITLE
Remove duplicate pressure limiting for Adami BC

### DIFF
--- a/src/schemes/boundary/dummy_particles/dummy_particles.jl
+++ b/src/schemes/boundary/dummy_particles/dummy_particles.jl
@@ -423,12 +423,6 @@ function compute_pressure!(boundary_model,
         boundary_pressure_extrapolation!(Val(parallelize), boundary_model, system,
                                          neighbor_system, system_coords, neighbor_coords, v,
                                          v_neighbor_system, semi)
-
-        @threaded semi for particle in eachparticle(system)
-            # Limit pressure to be non-negative to avoid attractive forces between fluid and
-            # boundary particles at free surfaces (sticking artifacts).
-            pressure[particle] = max(pressure[particle], 0)
-        end
     end
 
     @trixi_timeit timer() "inverse state equation" @threaded semi for particle in
@@ -453,6 +447,10 @@ function compute_adami_density!(boundary_model, system, system_coords, particle)
         # To impose no-slip condition
         compute_wall_velocity!(viscosity, system, system_coords, particle)
     end
+
+    # Limit pressure to be non-negative to avoid attractive forces between fluid and
+    # boundary particles at free surfaces (sticking artifacts).
+    pressure[particle] = max(pressure[particle], 0)
 
     # Apply inverse state equation to compute density (not used with EDAC)
     inverse_state_equation!(density, state_equation, pressure, particle)

--- a/src/schemes/boundary/system.jl
+++ b/src/schemes/boundary/system.jl
@@ -363,6 +363,7 @@ function update_final!(system::BoundarySPHSystem, v, u, v_ode, u_ode, semi, t;
                        update_from_callback=false)
     (; boundary_model) = system
 
+    # Note that `update_pressure!(::BoundarySPHSystem, ...)` is empty
     update_pressure!(boundary_model, system, v, u, v_ode, u_ode, semi)
 
     return system

--- a/src/schemes/solid/total_lagrangian_sph/system.jl
+++ b/src/schemes/solid/total_lagrangian_sph/system.jl
@@ -245,6 +245,8 @@ end
 function update_positions!(system::TotalLagrangianSPHSystem, v, u, v_ode, u_ode, semi, t)
     (; current_coordinates) = system
 
+    # `current_coordinates` stores the coordinates of both integrated and fixed particles.
+    # Copy the coordinates of the integrated particles from `u`.
     @threaded semi for particle in each_moving_particle(system)
         for i in 1:ndims(system)
             current_coordinates[i, particle] = u[i, particle]


### PR DESCRIPTION
The pressure limiting loop was run **for every neighbor system**.
I now moved it into the inverse state equation threaded loop/kernel, which also saves a bit of time on the GPU by doing two things in the same kernel.
I also change the code of the Adami pressure extrapolation to be a bit more readable and used `@inbounds` for slightly better GPU performance.