### PR TITLE
Show parallelization backend and Julia version in info callback

### DIFF
--- a/src/callbacks/info.jl
+++ b/src/callbacks/info.jl
@@ -135,7 +135,9 @@ function initialize_info_callback(discrete_callback, u, t, integrator;
     println()
 
     # Technical details
-    setup = Pair{String, Any}["#threads" => Threads.nthreads()]
+    setup = Pair{String, Any}["Julia version" => VERSION,
+                              "parallelization backend" => semi.parallelization_backend |> typeof |> nameof,
+                              "#threads" => Threads.nthreads()]
     summary_box(io, "Environment information", setup)
     println()
     println()


### PR DESCRIPTION
When running two simulations on the same machine, one on the CPU and one on the GPU, it is often useful to see which one is using the GPU and which one the CPU.