### PR TITLE
Reduce info prints

### DIFF
--- a/examples/fluid/falling_water_spheres_2d.jl
+++ b/examples/fluid/falling_water_spheres_2d.jl
@@ -92,7 +92,7 @@ boundary_system = BoundarySPHSystem(tank.boundary, boundary_model,
 semi = Semidiscretization(sphere_surface_tension, sphere, boundary_system)
 ode = semidiscretize(semi, tspan)
 
-info_callback = InfoCallback(interval=50)
+info_callback = InfoCallback(interval=1000)
 saving_callback = SolutionSavingCallback(dt=0.01, output_directory="out",
                                          prefix="", write_meta_data=true)
 

--- a/examples/fluid/falling_water_spheres_3d.jl
+++ b/examples/fluid/falling_water_spheres_3d.jl
@@ -36,7 +36,7 @@ fluid_smoothing_length = 1.0 * fluid_particle_spacing
 trixi_include(@__MODULE__,
               joinpath(examples_dir(), "fluid", "falling_water_spheres_2d.jl"),
               fluid_particle_spacing=fluid_particle_spacing, tspan=(0.0, 0.1),
-              initial_fluid_size=(0.0, 0.0, 0.0),
+              initial_fluid_size=(0.0, 0.0, 0.0), interval=100,
               tank_size=(2.0, 1.0, 0.1), sound_speed=sound_speed,
               faces=(true, true, true, true, true, false),
               acceleration=(0.0, 0.0, -gravity), sphere1=sphere1, sphere2=sphere2,

--- a/examples/fsi/falling_spheres_2d.jl
+++ b/examples/fsi/falling_spheres_2d.jl
@@ -123,7 +123,7 @@ solid_system_2 = TotalLagrangianSPHSystem(sphere2,
 semi = Semidiscretization(fluid_system, boundary_system, solid_system_1, solid_system_2)
 ode = semidiscretize(semi, tspan)
 
-info_callback = InfoCallback(interval=10)
+info_callback = InfoCallback(interval=50)
 saving_callback = SolutionSavingCallback(dt=0.02, output_directory="out", prefix="",
                                          write_meta_data=true)
 


### PR DESCRIPTION
I noticed that we have a lot of unnecessary info prints in some examples