### PR TITLE
Move update_callback_used flag to semidiscretization

### DIFF
--- a/src/callbacks/update.jl
+++ b/src/callbacks/update.jl
@@ -55,10 +55,8 @@ end
 function initial_update!(cb::UpdateCallback, u, t, integrator)
     semi = integrator.p
 
-    # Tell systems that `UpdateCallback` is used
-    foreach_system(semi) do system
-        set_callback_flag!(system, true)
-    end
+    # Tell the semidiscretization that the `UpdateCallback` is used
+    semi.update_callback_used[] = true
 
     return cb(integrator)
 end

--- a/src/general/semidiscretization.jl
+++ b/src/general/semidiscretization.jl
@@ -47,23 +47,26 @@ semi = Semidiscretization(fluid_system, boundary_system,
 └──────────────────────────────────────────────────────────────────────────────────────────────────┘
 ```
 """
-struct Semidiscretization{BACKEND, S, RU, RV, NS}
+struct Semidiscretization{BACKEND, S, RU, RV, NS, UCU}
     systems                 :: S
     ranges_u                :: RU
     ranges_v                :: RV
     neighborhood_searches   :: NS
     parallelization_backend :: BACKEND
+    update_callback_used    :: UCU
 
     # Dispatch at `systems` to distinguish this constructor from the one below when
     # 4 systems are passed.
     # This is an internal constructor only used in `test/count_allocations.jl`
     # and by Adapt.jl.
     function Semidiscretization(systems::Tuple, ranges_u, ranges_v, neighborhood_searches,
-                                parallelization_backend::PointNeighbors.ParallelizationBackend)
+                                parallelization_backend::PointNeighbors.ParallelizationBackend,
+                                update_callback_used)
         new{typeof(parallelization_backend), typeof(systems), typeof(ranges_u),
-            typeof(ranges_v), typeof(neighborhood_searches)}(systems, ranges_u, ranges_v,
-                                                             neighborhood_searches,
-                                                             parallelization_backend)
+            typeof(ranges_v), typeof(neighborhood_searches),
+            typeof(update_callback_used)}(systems, ranges_u, ranges_v,
+                                          neighborhood_searches, parallelization_backend,
+                                          update_callback_used)
     end
 end
 
@@ -92,8 +95,13 @@ function Semidiscretization(systems::Union{System, Nothing}...;
                            for neighbor in systems)
                      for system in systems)
 
+    # These will be set to true inside the `UpdateCallback`.
+    # Some techniques require the use of this callback, and this flag can be used
+    # to determine if the callback is used in a simulation.
+    update_callback_used = Ref(false)
+
     return Semidiscretization(systems, ranges_u, ranges_v, searches,
-                              parallelization_backend)
+                              parallelization_backend, update_callback_used)
 end
 
 # Inline show function e.g. Semidiscretization(neighborhood_search=...)
@@ -328,7 +336,8 @@ function semidiscretize(semi, tspan; reset_threads=true)
         semi_new = Semidiscretization(set_system_links.(semi_.systems, Ref(semi_)),
                                       semi_.ranges_u, semi_.ranges_v,
                                       semi_.neighborhood_searches,
-                                      semi_.parallelization_backend)
+                                      semi_.parallelization_backend,
+                                      semi_.update_callback_used)
     else
         semi_new = semi
     end
@@ -337,10 +346,10 @@ function semidiscretize(semi, tspan; reset_threads=true)
     foreach_system(semi_new) do system
         # Initialize this system
         initialize!(system, semi_new)
-
-        # Only for systems requiring the use of the `UpdateCallback`
-        set_callback_flag!(system, false)
     end
+
+    # Reset callback flag that will be set by the `UpdateCallback`
+    semi_new.update_callback_used[] = false
 
     return DynamicalODEProblem(kick!, drift!, v0_ode, u0_ode, tspan, semi_new)
 end
@@ -372,10 +381,10 @@ function restart_with!(semi, sol; reset_threads=true)
         u = wrap_u(sol.u[end].x[2], system, semi)
 
         restart_with!(system, v, u)
-
-        # Only for systems requiring the use of the `UpdateCallback`
-        set_callback_flag!(system, false)
     end
+
+    # Reset callback flag that will be set by the `UpdateCallback`
+    semi.update_callback_used[] = false
 
     return semi
 end
@@ -887,7 +896,7 @@ end
 function check_update_callback(semi)
     foreach_system(semi) do system
         # This check will be optimized away if the system does not require the callback
-        if requires_update_callback(system) && !update_callback_used(system)
+        if requires_update_callback(system) && !semi.update_callback_used[]
             system_name = system |> typeof |> nameof
             throw(ArgumentError("`UpdateCallback` is required for `$system_name`"))
         end
@@ -1007,6 +1016,5 @@ function set_system_links(system::OpenBoundarySPHSystem, semi)
                                  system.reference_pressure,
                                  system.reference_density,
                                  system.buffer,
-                                 system.update_callback_used,
                                  system.cache)
 end

--- a/src/general/system.jl
+++ b/src/general/system.jl
@@ -149,8 +149,6 @@ end
 
 # Only for systems requiring the use of the `UpdateCallback`
 @inline requires_update_callback(system) = false
-@inline update_callback_used(system) = false
-@inline set_callback_flag!(system, value) = system
 
 @inline initial_smoothing_length(system) = smoothing_length(system, nothing)
 

--- a/src/preprocessing/particle_packing/system.jl
+++ b/src/preprocessing/particle_packing/system.jl
@@ -161,8 +161,7 @@ function ParticlePackingSystem(shape::InitialCondition;
                                  background_pressure, tlsph, signed_distance_field,
                                  is_boundary, shift_length, nhs,
                                  fill(zero(ELTYPE), nparticles(shape)), particle_refinement,
-                                 nothing, Ref(false), fixed_system, cache,
-                                 advection_velocity)
+                                 nothing, fixed_system, cache, advection_velocity)
 end
 
 function Base.show(io::IO, system::ParticlePackingSystem)

--- a/src/schemes/boundary/open_boundary/system.jl
+++ b/src/schemes/boundary/open_boundary/system.jl
@@ -37,7 +37,7 @@ Open boundary system for in- and outflow particles.
     It is GPU-compatible (e.g., with CUDA.jl and AMDGPU.jl), but currently **not** supported with Metal.jl.
 """
 struct OpenBoundarySPHSystem{BM, ELTYPE, NDIMS, IC, FS, FSI, ARRAY1D, BC, FC, BZ, RV,
-                             RP, RD, B, UCU, C} <: System{NDIMS}
+                             RP, RD, B, C} <: System{NDIMS}
     boundary_model      :: BM
     initial_condition   :: IC
     fluid_system        :: FS

--- a/src/schemes/boundary/open_boundary/system.jl
+++ b/src/schemes/boundary/open_boundary/system.jl
@@ -38,46 +38,43 @@ Open boundary system for in- and outflow particles.
 """
 struct OpenBoundarySPHSystem{BM, ELTYPE, NDIMS, IC, FS, FSI, ARRAY1D, BC, FC, BZ, RV,
                              RP, RD, B, UCU, C} <: System{NDIMS}
-    boundary_model       :: BM
-    initial_condition    :: IC
-    fluid_system         :: FS
-    fluid_system_index   :: FSI
-    smoothing_length     :: ELTYPE
-    mass                 :: ARRAY1D # Array{ELTYPE, 1}: [particle]
-    density              :: ARRAY1D # Array{ELTYPE, 1}: [particle]
-    volume               :: ARRAY1D # Array{ELTYPE, 1}: [particle]
-    pressure             :: ARRAY1D # Array{ELTYPE, 1}: [particle]
-    boundary_candidates  :: BC      # Array{UInt32, 1}: [particle]
-    fluid_candidates     :: FC      # Array{UInt32, 1}: [particle]
-    boundary_zone        :: BZ
-    reference_velocity   :: RV
-    reference_pressure   :: RP
-    reference_density    :: RD
-    buffer               :: B
-    update_callback_used :: UCU
-    cache                :: C
+    boundary_model      :: BM
+    initial_condition   :: IC
+    fluid_system        :: FS
+    fluid_system_index  :: FSI
+    smoothing_length    :: ELTYPE
+    mass                :: ARRAY1D # Array{ELTYPE, 1}: [particle]
+    density             :: ARRAY1D # Array{ELTYPE, 1}: [particle]
+    volume              :: ARRAY1D # Array{ELTYPE, 1}: [particle]
+    pressure            :: ARRAY1D # Array{ELTYPE, 1}: [particle]
+    boundary_candidates :: BC      # Array{UInt32, 1}: [particle]
+    fluid_candidates    :: FC      # Array{UInt32, 1}: [particle]
+    boundary_zone       :: BZ
+    reference_velocity  :: RV
+    reference_pressure  :: RP
+    reference_density   :: RD
+    buffer              :: B
+    cache               :: C
 end
 
 function OpenBoundarySPHSystem(boundary_model, initial_condition, fluid_system,
                                fluid_system_index, smoothing_length, mass, density, volume,
                                pressure, boundary_candidates, fluid_candidates,
                                boundary_zone, reference_velocity,
-                               reference_pressure, reference_density, buffer,
-                               update_callback_used, cache)
+                               reference_pressure, reference_density, buffer, cache)
     OpenBoundarySPHSystem{typeof(boundary_model), eltype(mass), ndims(initial_condition),
                           typeof(initial_condition), typeof(fluid_system),
                           typeof(fluid_system_index), typeof(mass),
                           typeof(boundary_candidates), typeof(fluid_candidates),
                           typeof(boundary_zone), typeof(reference_velocity),
                           typeof(reference_pressure), typeof(reference_density),
-                          typeof(buffer), typeof(update_callback_used),
+                          typeof(buffer),
                           typeof(cache)}(boundary_model, initial_condition, fluid_system,
                                          fluid_system_index, smoothing_length, mass,
                                          density, volume, pressure, boundary_candidates,
                                          fluid_candidates, boundary_zone,
                                          reference_velocity, reference_pressure,
-                                         reference_density, buffer, update_callback_used,
-                                         cache)
+                                         reference_density, buffer, cache)
 end
 
 function OpenBoundarySPHSystem(boundary_zone::BoundaryZone;
@@ -149,8 +146,6 @@ function OpenBoundarySPHSystem(boundary_zone::BoundaryZone;
                                        reference_density, reference_velocity,
                                        reference_pressure)
 
-    # These will be set later
-    update_callback_used = Ref(false)
     fluid_system_index = Ref(0)
 
     smoothing_length = initial_smoothing_length(fluid_system)
@@ -162,8 +157,7 @@ function OpenBoundarySPHSystem(boundary_zone::BoundaryZone;
                                  fluid_system_index, smoothing_length, mass, density,
                                  volume, pressure, boundary_candidates, fluid_candidates,
                                  boundary_zone, reference_velocity_,
-                                 reference_pressure_, reference_density_, buffer,
-                                 update_callback_used, cache)
+                                 reference_pressure_, reference_density_, buffer, cache)
 end
 
 function create_cache_open_boundary(boundary_model, initial_condition,
@@ -226,14 +220,8 @@ end
     return ELTYPE
 end
 
+# The `UpdateCallback` is required to update particle positions between time steps
 @inline requires_update_callback(system::OpenBoundarySPHSystem) = true
-@inline update_callback_used(system::OpenBoundarySPHSystem) = system.update_callback_used[]
-
-function set_callback_flag!(system::OpenBoundarySPHSystem, value)
-    system.update_callback_used[] = value
-
-    return system
-end
 
 function corresponding_fluid_system(system::OpenBoundarySPHSystem, semi)
     return system.fluid_system

--- a/test/count_allocations.jl
+++ b/test/count_allocations.jl
@@ -15,7 +15,7 @@ function copy_semi_with_no_update_nhs(semi)
                                   for searches in semi.neighborhood_searches)
 
     return Semidiscretization(semi.systems, semi.ranges_u, semi.ranges_v,
-                              neighborhood_searches, SerialBackend())
+                              neighborhood_searches, SerialBackend(), Ref(true))
 end
 
 # Forward `foreach_neighbor` to wrapped neighborhood search


### PR DESCRIPTION
Based on #864.

It makes more sense to have this in the semidiscretization, as it is a global flag for the simulation.