### PR TITLE
Make `PrescribedMotion` more powerful by passing the initial position

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,10 @@ used in the Julia ecosystem. Notable changes will be documented in this file for
 
 - Renamed `OpenBoundarySPHSystem` to `OpenBoundarySystem`.
 
-- Renamed `BoundaryMovement` to `PrescribedMotion`.
+- Renamed `BoundaryMovement` to `PrescribedMotion`. The `movement_function` must now be
+  a function of `(x, t)` returning the *new position* instead of an offset.
+  For example, `movement_function(t) = SVector(t, 0.0)` now needs to be
+  `movement_function(x, t) = x + SVector(t, 0.0)`.
 
 - Renamed directory `solid` to `structure` in the examples file tree.
   VTK files for the `TotalLagrangianSPHSystem` are now also called `structure_*`.
@@ -67,7 +70,7 @@ used in the Julia ecosystem. Notable changes will be documented in this file for
 
 - Fix the coordinates used for TLSPH in Adami extrapolation (#853)
 - Fix PST for small smoothing length factors (#834)
-- The TVF model has been improved to integrate correctly with time stepping (#864) 
+- The TVF model has been improved to integrate correctly with time stepping (#864)
 
 
 ## Version 0.3.1
@@ -277,4 +280,3 @@ Features:
 #### TLSPH
 
 An implementation of TLSPH (Total Lagrangian Smoothed Particle Hydrodynamics) for solid bodies enabling FSI (Fluid Structure Interactions).
-

--- a/examples/fluid/accelerated_tank_2d.jl
+++ b/examples/fluid/accelerated_tank_2d.jl
@@ -12,7 +12,7 @@ using OrdinaryDiffEq
 fluid_particle_spacing = 0.05
 
 # Function for moving boundaries
-movement_function(t) = SVector(0.0, 0.5 * 9.81 * t^2)
+movement_function(x, t) = x + SVector(0.0, 0.5 * 9.81 * t^2)
 
 is_moving(t) = true
 

--- a/examples/fluid/lid_driven_cavity_2d.jl
+++ b/examples/fluid/lid_driven_cavity_2d.jl
@@ -79,7 +79,7 @@ end
 # ==========================================================================================
 # ==== Boundary
 
-lid_movement_function(t) = SVector(VELOCITY_LID * t, 0.0)
+lid_movement_function(x, t) = x + SVector(VELOCITY_LID * t, 0.0)
 
 is_moving(t) = true
 

--- a/examples/fluid/moving_wall_2d.jl
+++ b/examples/fluid/moving_wall_2d.jl
@@ -36,7 +36,7 @@ tank = RectangularTank(fluid_particle_spacing, initial_fluid_size, tank_size, fl
 reset_wall!(tank, (false, true, false, false), (0.0, tank.fluid_size[1], 0.0, 0.0))
 
 # Movement function
-movement_function(t) = SVector(0.5t^2, 0.0)
+movement_function(x, t) = x + SVector(0.5 * t^2, 0.0)
 
 is_moving(t) = t < 1.5
 

--- a/examples/fsi/dam_break_gate_2d.jl
+++ b/examples/fsi/dam_break_gate_2d.jl
@@ -60,7 +60,7 @@ gate = RectangularShape(boundary_particle_spacing,
                         (initial_fluid_size[1], 0.0), density=fluid_density)
 
 # Movement of the gate according to the paper
-movement_function(t) = SVector(0.0, -285.115t^3 + 72.305t^2 + 0.1463t)
+movement_function(x, t) = x + SVector(0.0, -285.115 * t^3 + 72.305 * t^2 + 0.1463 * t)
 is_moving(t) = t < 0.1
 
 gate_movement = PrescribedMotion(movement_function, is_moving)

--- a/src/schemes/boundary/prescribed_motion.jl
+++ b/src/schemes/boundary/prescribed_motion.jl
@@ -29,7 +29,7 @@ is_moving2(t) = true
 motion2 = PrescribedMotion(movement_function2, is_moving2)
 
 # output
-PrescribedMotion{typeof(movement_function2), typeof(is_moving2), Vector{Int64}}(movement_function2, is_moving2, [])
+PrescribedMotion{typeof(movement_function2), typeof(is_moving2), Vector{Int64}}(movement_function2, is_moving2, Int64[])
 ```
 """
 struct PrescribedMotion{MF, IM, MP}
@@ -41,11 +41,6 @@ end
 # The default constructor needs to be accessible for Adapt.jl to work with this struct.
 # See the comments in general/gpu.jl for more details.
 function PrescribedMotion(movement_function, is_moving; moving_particles=nothing)
-    if !(movement_function(0.0) isa SVector)
-        @warn "Return value of `movement_function` is not of type `SVector`. " *
-              "Returning regular `Vector`s causes allocations and significant performance overhead."
-    end
-
     # Default value is an empty vector, which will be resized in the `WallBoundarySystem`
     # constructor to move all particles.
     moving_particles = isnothing(moving_particles) ? Int[] : vec(moving_particles)

--- a/src/schemes/boundary/prescribed_motion.jl
+++ b/src/schemes/boundary/prescribed_motion.jl
@@ -38,6 +38,16 @@ struct PrescribedMotion{MF, IM, MP}
     moving_particles  :: MP # Vector{Int}
 end
 
+# The default constructor needs to be accessible for Adapt.jl to work with this struct.
+# See the comments in general/gpu.jl for more details.
+function PrescribedMotion(movement_function, is_moving; moving_particles=nothing)
+    # Default value is an empty vector, which will be resized in the `WallBoundarySystem`
+    # constructor to move all particles.
+    moving_particles = isnothing(moving_particles) ? Int[] : vec(moving_particles)
+
+    return PrescribedMotion(movement_function, is_moving, moving_particles)
+end
+
 function initialize!(prescribed_motion::PrescribedMotion, initial_condition)
     # Test `movement_function` return type`
     pos = extract_svector(initial_condition.coordinates,
@@ -54,16 +64,6 @@ function initialize!(prescribed_motion::PrescribedMotion, initial_condition)
         resize!(prescribed_motion.moving_particles, nparticles(initial_condition))
         prescribed_motion.moving_particles .= collect(1:nparticles(initial_condition))
     end
-end
-
-# The default constructor needs to be accessible for Adapt.jl to work with this struct.
-# See the comments in general/gpu.jl for more details.
-function PrescribedMotion(movement_function, is_moving; moving_particles=nothing)
-    # Default value is an empty vector, which will be resized in the `WallBoundarySystem`
-    # constructor to move all particles.
-    moving_particles = isnothing(moving_particles) ? Int[] : vec(moving_particles)
-
-    return PrescribedMotion(movement_function, is_moving, moving_particles)
 end
 
 function (prescribed_motion::PrescribedMotion)(system, t, semi)

--- a/src/schemes/boundary/prescribed_motion.jl
+++ b/src/schemes/boundary/prescribed_motion.jl
@@ -49,7 +49,7 @@ function PrescribedMotion(movement_function, is_moving; moving_particles=nothing
 end
 
 function initialize!(prescribed_motion::PrescribedMotion, initial_condition)
-    # Test `movement_function` return type`
+    # Test `movement_function` return type
     pos = extract_svector(initial_condition.coordinates,
                           Val(size(initial_condition.coordinates, 1)), 1)
     if !(prescribed_motion.movement_function(pos, 0.0) isa SVector)

--- a/src/schemes/boundary/wall_boundary/system.jl
+++ b/src/schemes/boundary/wall_boundary/system.jl
@@ -60,7 +60,16 @@ end
 
 create_cache_boundary(::Nothing, initial_condition) = (;)
 
-function create_cache_boundary(::PrescribedMotion, initial_condition)
+function create_cache_boundary(prescribed_motion::PrescribedMotion, initial_condition)
+    (; movement_function) = prescribed_motion
+
+    pos = extract_svector(initial_condition.coordinates,
+                          Val(size(initial_condition.coordinates, 1)), 1)
+    if !(movement_function(pos, 0.0) isa SVector)
+        @warn "Return value of `movement_function` is not of type `SVector`. " *
+              "Returning regular `Vector`s causes allocations and significant performance overhead."
+    end
+
     initial_coordinates = copy(initial_condition.coordinates)
     velocity = zero(initial_condition.velocity)
     acceleration = zero(initial_condition.velocity)

--- a/src/schemes/boundary/wall_boundary/system.jl
+++ b/src/schemes/boundary/wall_boundary/system.jl
@@ -42,16 +42,10 @@ function WallBoundarySystem(initial_condition, model; prescribed_motion=nothing,
     coordinates = copy(initial_condition.coordinates)
 
     ismoving = Ref(!isnothing(prescribed_motion))
+    initialize!(prescribed_motion, initial_condition)
 
     cache = create_cache_boundary(prescribed_motion, initial_condition)
     cache = (cache..., color=Int(color_value))
-
-    if prescribed_motion !== nothing && isempty(prescribed_motion.moving_particles)
-        # Default is an empty vector, since the number of particles is not known when
-        # instantiating `PrescribedMotion`.
-        resize!(prescribed_motion.moving_particles, nparticles(initial_condition))
-        prescribed_motion.moving_particles .= collect(1:nparticles(initial_condition))
-    end
 
     # Because of dispatches boundary model needs to be first!
     return WallBoundarySystem(initial_condition, coordinates, model, prescribed_motion,
@@ -61,15 +55,6 @@ end
 create_cache_boundary(::Nothing, initial_condition) = (;)
 
 function create_cache_boundary(prescribed_motion::PrescribedMotion, initial_condition)
-    (; movement_function) = prescribed_motion
-
-    pos = extract_svector(initial_condition.coordinates,
-                          Val(size(initial_condition.coordinates, 1)), 1)
-    if !(movement_function(pos, 0.0) isa SVector)
-        @warn "Return value of `movement_function` is not of type `SVector`. " *
-              "Returning regular `Vector`s causes allocations and significant performance overhead."
-    end
-
     initial_coordinates = copy(initial_condition.coordinates)
     velocity = zero(initial_condition.velocity)
     acceleration = zero(initial_condition.velocity)

--- a/test/systems/boundary_system.jl
+++ b/test/systems/boundary_system.jl
@@ -36,12 +36,12 @@
             initial_condition = InitialCondition(; coordinates, mass, density)
             model = (; hydrodynamic_mass=3)
 
-            function movement_function(t)
+            function movement_function(x, t)
                 if NDIMS == 2
-                    return SVector(0.5 * t, 0.3 * t^2)
+                    return x + SVector(0.5 * t, 0.3 * t^2)
                 end
 
-                return SVector(0.5 * t, 0.3 * t^2, 0.1 * t^3)
+                return x + SVector(0.5 * t, 0.3 * t^2, 0.1 * t^3)
             end
 
             is_moving(t) = t < 1.0


### PR DESCRIPTION
Based on #903, #904, #905, #908.

Here is an example for a
Before:
```julia
movement_function(t) = SVector(t, 0.0)
```
Now:
```julia
movement_function(x, t) = x + SVector(t, 0.0)
```
While the previous version could only do translations, the new version also allows for rotations.