### PR TITLE
Make `kernel_grad` threshold compatible with single precision and small particle spacing

### DIFF
--- a/examples/n_body/n_body_system.jl
+++ b/examples/n_body/n_body_system.jl
@@ -59,9 +59,9 @@ function TrixiParticles.interact!(dv, v_particle_system, u_particle_system,
     TrixiParticles.foreach_point_neighbor(particle_system, neighbor_system,
                                           system_coords, neighbor_coords,
                                           semi) do particle, neighbor, pos_diff, distance
-        # Only consider particles with a distance > 0
-        # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
-        distance^2 < sqrt(eps(distance^2)) && return
+        # Only consider particles with a distance > 0.
+        # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913).
+        distance^2 < eps(distance^2) && return
 
         # Original version
         # dv = -G * mass[neighbor] * pos_diff / norm(pos_diff)^3

--- a/examples/n_body/n_body_system.jl
+++ b/examples/n_body/n_body_system.jl
@@ -60,7 +60,8 @@ function TrixiParticles.interact!(dv, v_particle_system, u_particle_system,
                                           system_coords, neighbor_coords,
                                           semi) do particle, neighbor, pos_diff, distance
         # Only consider particles with a distance > 0
-        distance < sqrt(eps()) && return
+        # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
+        distance^2 < sqrt(eps(distance^2)) && return
 
         # Original version
         # dv = -G * mass[neighbor] * pos_diff / norm(pos_diff)^3

--- a/src/general/corrections.jl
+++ b/src/general/corrections.jl
@@ -216,7 +216,7 @@ function compute_correction_values!(system,
                        smoothing_length(system, particle))
 
             kernel_correction_coefficient[particle] += volume * W
-            if distance > sqrt(eps())
+            if distance^2 > eps(distance^2)
                 grad_W = kernel_grad(system_smoothing_kernel(system), pos_diff, distance,
                                      smoothing_length(system, particle))
                 tmp = volume * grad_W

--- a/src/general/corrections.jl
+++ b/src/general/corrections.jl
@@ -216,6 +216,8 @@ function compute_correction_values!(system,
                        smoothing_length(system, particle))
 
             kernel_correction_coefficient[particle] += volume * W
+
+            # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
             if distance^2 > eps(distance^2)
                 grad_W = kernel_grad(system_smoothing_kernel(system), pos_diff, distance,
                                      smoothing_length(system, particle))

--- a/src/general/smoothing_kernels.jl
+++ b/src/general/smoothing_kernels.jl
@@ -15,7 +15,6 @@ abstract type AbstractSmoothingKernel{NDIMS} end
     return kernel_deriv(kernel, distance, h) / distance * pos_diff
 end
 
-
 @inline function corrected_kernel_grad(kernel, pos_diff, distance, h, correction, system,
                                        particle)
     return kernel_grad(kernel, pos_diff, distance, h)

--- a/src/general/smoothing_kernels.jl
+++ b/src/general/smoothing_kernels.jl
@@ -3,7 +3,7 @@ abstract type AbstractSmoothingKernel{NDIMS} end
 @inline Base.ndims(::AbstractSmoothingKernel{NDIMS}) where {NDIMS} = NDIMS
 
 @inline function kernel_grad(kernel, pos_diff, distance, h)
-    # Numerical precision note:
+    # Numerical precision note (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913):
     # We use `eps(h^2)` as a threshold to avoid division by very small distances.
     # Here, `h` is the smoothing length.
     # The comparison `distance^2 < eps(h^2)` is preferred over `distance < sqrt(eps(h^2))`

--- a/src/general/smoothing_kernels.jl
+++ b/src/general/smoothing_kernels.jl
@@ -3,11 +3,18 @@ abstract type AbstractSmoothingKernel{NDIMS} end
 @inline Base.ndims(::AbstractSmoothingKernel{NDIMS}) where {NDIMS} = NDIMS
 
 @inline function kernel_grad(kernel, pos_diff, distance, h)
-    # TODO Use `eps` relative to `h` to allow scaling of simulations
-    distance < sqrt(eps(typeof(h))) && return zero(pos_diff)
+    # Numerical precision note:
+    # We use `eps(h^2)` as a threshold to avoid division by very small distances.
+    # Here, `h` is the smoothing length.
+    # The comparison `distance^2 < eps(h^2)` is preferred over `distance < sqrt(eps(h^2))`
+    # for efficiency, since it avoids an unnecessary square root.
+    # This ensures that for particles that are extremely close (or coincident),
+    # the gradient is set to zero, which is physically and numerically justified in SPH simulations.
+    distance^2 < eps(h^2) && return zero(pos_diff)
 
     return kernel_deriv(kernel, distance, h) / distance * pos_diff
 end
+
 
 @inline function corrected_kernel_grad(kernel, pos_diff, distance, h, correction, system,
                                        particle)

--- a/src/preprocessing/particle_packing/rhs.jl
+++ b/src/preprocessing/particle_packing/rhs.jl
@@ -8,6 +8,10 @@ function interact!(dv, v_particle_system, u_particle_system,
     # Loop over all pairs of particles and neighbors within the kernel cutoff
     foreach_point_neighbor(system, neighbor_system, system_coords, neighbor_coords,
                            semi) do particle, neighbor, pos_diff, distance
+        # Only consider particles with a distance > 0.
+        # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
+        distance^2 < eps(distance^2) && return
+
         rho_a = system.initial_condition.density[particle]
         rho_b = neighbor_system.initial_condition.density[neighbor]
 

--- a/src/preprocessing/particle_packing/rhs.jl
+++ b/src/preprocessing/particle_packing/rhs.jl
@@ -8,9 +8,6 @@ function interact!(dv, v_particle_system, u_particle_system,
     # Loop over all pairs of particles and neighbors within the kernel cutoff
     foreach_point_neighbor(system, neighbor_system, system_coords, neighbor_coords,
                            semi) do particle, neighbor, pos_diff, distance
-        # Only consider particles with a distance > 0
-        distance < sqrt(eps()) && return
-
         rho_a = system.initial_condition.density[particle]
         rho_b = neighbor_system.initial_condition.density[neighbor]
 

--- a/src/schemes/boundary/open_boundary/method_of_characteristics.jl
+++ b/src/schemes/boundary/open_boundary/method_of_characteristics.jl
@@ -178,6 +178,7 @@ function evaluate_characteristics!(system, v, u, v_ode, u_ode, semi, t)
             for neighbor in each_integrated_particle(system)
                 # Make sure that only neighbors in the influence of
                 # the fluid particles are used.
+                # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
                 if volume[neighbor]^2 > eps(volume[neighbor]^2)
                     avg_J1 += previous_characteristics[1, neighbor]
                     avg_J2 += previous_characteristics[2, neighbor]

--- a/src/schemes/boundary/open_boundary/method_of_characteristics.jl
+++ b/src/schemes/boundary/open_boundary/method_of_characteristics.jl
@@ -178,7 +178,7 @@ function evaluate_characteristics!(system, v, u, v_ode, u_ode, semi, t)
             for neighbor in each_integrated_particle(system)
                 # Make sure that only neighbors in the influence of
                 # the fluid particles are used.
-                if isapprox(volume[neighbor], 0)
+                if volume[neighbor]^2 > eps(volume[neighbor]^2)
                     avg_J1 += previous_characteristics[1, neighbor]
                     avg_J2 += previous_characteristics[2, neighbor]
                     avg_J3 += previous_characteristics[3, neighbor]

--- a/src/schemes/boundary/open_boundary/method_of_characteristics.jl
+++ b/src/schemes/boundary/open_boundary/method_of_characteristics.jl
@@ -178,7 +178,7 @@ function evaluate_characteristics!(system, v, u, v_ode, u_ode, semi, t)
             for neighbor in each_integrated_particle(system)
                 # Make sure that only neighbors in the influence of
                 # the fluid particles are used.
-                if volume[neighbor]^2 > eps(volume[neighbor]^2)
+                if isapprox(volume[neighbor], 0)
                     avg_J1 += previous_characteristics[1, neighbor]
                     avg_J2 += previous_characteristics[2, neighbor]
                     avg_J3 += previous_characteristics[3, neighbor]

--- a/src/schemes/boundary/open_boundary/method_of_characteristics.jl
+++ b/src/schemes/boundary/open_boundary/method_of_characteristics.jl
@@ -178,7 +178,7 @@ function evaluate_characteristics!(system, v, u, v_ode, u_ode, semi, t)
             for neighbor in each_integrated_particle(system)
                 # Make sure that only neighbors in the influence of
                 # the fluid particles are used.
-                if volume[neighbor] > sqrt(eps())
+                if volume[neighbor]^2 > eps(volume[neighbor]^2)
                     avg_J1 += previous_characteristics[1, neighbor]
                     avg_J2 += previous_characteristics[2, neighbor]
                     avg_J3 += previous_characteristics[3, neighbor]

--- a/src/schemes/fluid/entropically_damped_sph/rhs.jl
+++ b/src/schemes/fluid/entropically_damped_sph/rhs.jl
@@ -67,10 +67,11 @@ function interact!(dv, v_particle_system, u_particle_system,
         dv_adhesion = adhesion_force(surface_tension_a, particle_system, neighbor_system,
                                      particle, neighbor, pos_diff, distance)
 
+        dv_particle = dv_pressure + dv_viscosity_ + dv_tvf + dv_surface_tension +
+                      dv_adhesion
+
         for i in 1:ndims(particle_system)
-            @inbounds dv[i,
-                         particle] += dv_pressure[i] + dv_viscosity_[i] + dv_tvf[i] +
-                                      dv_surface_tension[i] + dv_adhesion[i]
+            @inbounds dv[i, particle] += dv_particle[i]
         end
 
         v_diff = current_velocity(v_particle_system, particle_system, particle) -

--- a/src/schemes/fluid/surface_tension.jl
+++ b/src/schemes/fluid/surface_tension.jl
@@ -175,7 +175,7 @@ end
                                        particle, neighbor, pos_diff, distance,
                                        rho_a, rho_b, grad_kernel)
     # No cohesion with oneself.
-    # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
+    # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913).
     distance^2 < sqrt(eps(distance^2)) && return zero(pos_diff)
 
     m_b = hydrodynamic_mass(neighbor_system, neighbor)
@@ -196,7 +196,7 @@ end
 
     smoothing_length_ = smoothing_length(particle_system, particle)
     # No surface tension with oneself.
-    # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
+    # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913).
     distance^2 < sqrt(eps(distance^2)) && return zero(pos_diff)
 
     m_b = hydrodynamic_mass(neighbor_system, neighbor)
@@ -218,7 +218,7 @@ end
     (; surface_tension_coefficient) = surface_tension_a
 
     # No surface tension with oneself.
-    # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
+    # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913).
     distance^2 < sqrt(eps(distance^2)) && return zero(pos_diff)
 
     n_a = surface_normal(particle_system, particle)
@@ -289,7 +289,7 @@ end
     (; surface_tension_coefficient) = surface_tension_a
 
     # No surface tension with oneself.
-    # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
+    # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913).
     distance^2 < sqrt(eps(distance^2)) && return zero(pos_diff)
 
     S_a = stress_tensor(particle_system, particle)
@@ -307,7 +307,7 @@ end
     (; adhesion_coefficient) = neighbor_system
 
     # No adhesion with oneself.
-    # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
+    # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913).
     distance^2 < sqrt(eps(distance^2)) && return zero(pos_diff)
 
     # No reason to calculate the adhesion force if adhesion coefficient is near zero

--- a/src/schemes/fluid/surface_tension.jl
+++ b/src/schemes/fluid/surface_tension.jl
@@ -174,8 +174,9 @@ end
                                        neighbor_system::AbstractFluidSystem,
                                        particle, neighbor, pos_diff, distance,
                                        rho_a, rho_b, grad_kernel)
-    # No cohesion with oneself
-    distance < sqrt(eps()) && return zero(pos_diff)
+    # No cohesion with oneself.
+    # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
+    distance^2 < sqrt(eps(distance^2)) && return zero(pos_diff)
 
     m_b = hydrodynamic_mass(neighbor_system, neighbor)
     support_radius = compact_support(smoothing_kernel,
@@ -194,8 +195,9 @@ end
     (; surface_tension_coefficient) = surface_tension_a
 
     smoothing_length_ = smoothing_length(particle_system, particle)
-    # No surface tension with oneself
-    distance < sqrt(eps()) && return zero(pos_diff)
+    # No surface tension with oneself.
+    # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
+    distance^2 < sqrt(eps(distance^2)) && return zero(pos_diff)
 
     m_b = hydrodynamic_mass(neighbor_system, neighbor)
     n_a = surface_normal(particle_system, particle)
@@ -215,8 +217,9 @@ end
                                        rho_a, rho_b, grad_kernel)
     (; surface_tension_coefficient) = surface_tension_a
 
-    # No surface tension with oneself
-    distance < sqrt(eps()) && return zero(pos_diff)
+    # No surface tension with oneself.
+    # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
+    distance^2 < sqrt(eps(distance^2)) && return zero(pos_diff)
 
     n_a = surface_normal(particle_system, particle)
     curvature_a = curvature(particle_system, particle)
@@ -285,8 +288,9 @@ end
                                        rho_a, rho_b, grad_kernel)
     (; surface_tension_coefficient) = surface_tension_a
 
-    # No surface tension with oneself
-    distance < sqrt(eps()) && return zero(pos_diff)
+    # No surface tension with oneself.
+    # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
+    distance^2 < sqrt(eps(distance^2)) && return zero(pos_diff)
 
     S_a = stress_tensor(particle_system, particle)
     S_b = stress_tensor(neighbor_system, neighbor)
@@ -302,8 +306,9 @@ end
                                 pos_diff, distance)
     (; adhesion_coefficient) = neighbor_system
 
-    # No adhesion with oneself
-    distance < sqrt(eps()) && return zero(pos_diff)
+    # No adhesion with oneself.
+    # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
+    distance^2 < sqrt(eps(distance^2)) && return zero(pos_diff)
 
     # No reason to calculate the adhesion force if adhesion coefficient is near zero
     abs(adhesion_coefficient) < eps() && return zero(pos_diff)

--- a/src/schemes/fluid/weakly_compressible_sph/density_diffusion.jl
+++ b/src/schemes/fluid/weakly_compressible_sph/density_diffusion.jl
@@ -187,9 +187,6 @@ function update!(density_diffusion::DensityDiffusionAntuono, v, u, system, semi)
     foreach_point_neighbor(system, system, system_coords, system_coords, semi;
                            points=each_integrated_particle(system)) do particle, neighbor,
                                                                        pos_diff, distance
-        # Only consider particles with a distance > 0
-        distance < sqrt(eps(typeof(distance))) && return
-
         rho_a = current_density(v, system, particle)
         rho_b = current_density(v, system, neighbor)
 
@@ -215,8 +212,9 @@ end
                                                 pos_diff, distance, m_b, rho_a, rho_b,
                                                 particle_system::AbstractFluidSystem,
                                                 grad_kernel)
-    # Density diffusion terms are all zero for distance zero
-    distance < sqrt(eps(typeof(distance))) && return
+    # Density diffusion terms are all zero for distance zero.
+    # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
+    distance^2 < sqrt(eps(distance^2)) && return
 
     (; delta) = density_diffusion
     sound_speed = system_sound_speed(particle_system)

--- a/src/schemes/fluid/weakly_compressible_sph/density_diffusion.jl
+++ b/src/schemes/fluid/weakly_compressible_sph/density_diffusion.jl
@@ -187,7 +187,8 @@ function update!(density_diffusion::DensityDiffusionAntuono, v, u, system, semi)
     foreach_point_neighbor(system, system, system_coords, system_coords, semi;
                            points=each_integrated_particle(system)) do particle, neighbor,
                                                                        pos_diff, distance
-        # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
+        # Density diffusion terms are all zero for distance zero.
+        # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913).
         distance^2 < sqrt(eps(distance^2)) && return
 
         rho_a = current_density(v, system, particle)
@@ -216,7 +217,7 @@ end
                                                 particle_system::AbstractFluidSystem,
                                                 grad_kernel)
     # Density diffusion terms are all zero for distance zero.
-    # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
+    # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913).
     distance^2 < sqrt(eps(distance^2)) && return
 
     (; delta) = density_diffusion

--- a/src/schemes/fluid/weakly_compressible_sph/density_diffusion.jl
+++ b/src/schemes/fluid/weakly_compressible_sph/density_diffusion.jl
@@ -187,6 +187,9 @@ function update!(density_diffusion::DensityDiffusionAntuono, v, u, system, semi)
     foreach_point_neighbor(system, system, system_coords, system_coords, semi;
                            points=each_integrated_particle(system)) do particle, neighbor,
                                                                        pos_diff, distance
+        # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
+        distance^2 < sqrt(eps(distance^2)) && return
+
         rho_a = current_density(v, system, particle)
         rho_b = current_density(v, system, neighbor)
 

--- a/src/schemes/fluid/weakly_compressible_sph/rhs.jl
+++ b/src/schemes/fluid/weakly_compressible_sph/rhs.jl
@@ -86,10 +86,11 @@ function interact!(dv, v_particle_system, u_particle_system,
         dv_adhesion = adhesion_force(surface_tension_a, particle_system, neighbor_system,
                                      particle, neighbor, pos_diff, distance)
 
+        dv_particle = dv_pressure + dv_viscosity_ + dv_tvf + dv_surface_tension +
+                      dv_adhesion
+
         for i in 1:ndims(particle_system)
-            @inbounds dv[i,
-                         particle] += dv_pressure[i] + dv_viscosity_[i] + dv_tvf[i] +
-                                      dv_surface_tension[i] + dv_adhesion[i]
+            @inbounds dv[i, particle] += dv_particle[i]
             # Debug example
             # debug_array[i, particle] += dv_pressure[i]
         end

--- a/src/schemes/structure/discrete_element_method/rhs.jl
+++ b/src/schemes/structure/discrete_element_method/rhs.jl
@@ -12,7 +12,8 @@ function interact!(dv, v_particle_system, u_particle_system, v_neighbor_system,
                                                                                 neighbor,
                                                                                 pos_diff,
                                                                                 distance
-        distance < sqrt(eps()) && return
+        # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
+        distance^2 < sqrt(eps(distance^2)) && return
 
         # Retrieve particle properties
         m_a = particle_system.mass[particle]

--- a/src/schemes/structure/total_lagrangian_sph/rhs.jl
+++ b/src/schemes/structure/total_lagrangian_sph/rhs.jl
@@ -22,6 +22,10 @@ end
                            points=each_integrated_particle(system)) do particle, neighbor,
                                                                        initial_pos_diff,
                                                                        initial_distance
+        # Only consider particles with a distance > 0.
+        # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
+        initial_distance^2 < eps(initial_distance^2) && return
+
         rho_a = @inbounds system.material_density[particle]
         rho_b = @inbounds system.material_density[neighbor]
 
@@ -48,10 +52,10 @@ end
                                           current_pos_diff, current_distance,
                                           m_a, m_b, rho_a, rho_b, grad_kernel)
 
+        dv_particle = dv_stress + dv_penalty_force_ + dv_viscosity
+
         for i in 1:ndims(system)
-            @inbounds dv[i,
-                         particle] += dv_stress[i] + dv_penalty_force_[i] +
-                                      dv_viscosity[i]
+            @inbounds dv[i, particle] += dv_particle[i]
         end
 
         # TODO continuity equation for boundary model with `ContinuityDensity`?
@@ -77,6 +81,10 @@ function interact!(dv, v_particle_system, u_particle_system,
                                                                                 neighbor,
                                                                                 pos_diff,
                                                                                 distance
+        # Only consider particles with a distance > 0.
+        # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
+        distance^2 < eps(distance^2) && return
+
         # Apply the same force to the structure particle
         # that the fluid particle experiences due to the structure particle.
         # Note that the same arguments are passed here as in fluid-structure interact!,

--- a/src/schemes/structure/total_lagrangian_sph/rhs.jl
+++ b/src/schemes/structure/total_lagrangian_sph/rhs.jl
@@ -22,9 +22,6 @@ end
                            points=each_integrated_particle(system)) do particle, neighbor,
                                                                        initial_pos_diff,
                                                                        initial_distance
-        # Only consider particles with a distance > 0
-        initial_distance < sqrt(eps()) && return
-
         rho_a = @inbounds system.material_density[particle]
         rho_b = @inbounds system.material_density[neighbor]
 

--- a/src/schemes/structure/total_lagrangian_sph/rhs.jl
+++ b/src/schemes/structure/total_lagrangian_sph/rhs.jl
@@ -77,9 +77,6 @@ function interact!(dv, v_particle_system, u_particle_system,
                                                                                 neighbor,
                                                                                 pos_diff,
                                                                                 distance
-        # Only consider particles with a distance > 0
-        distance < sqrt(eps()) && return
-
         # Apply the same force to the structure particle
         # that the fluid particle experiences due to the structure particle.
         # Note that the same arguments are passed here as in fluid-structure interact!,

--- a/src/schemes/structure/total_lagrangian_sph/system.jl
+++ b/src/schemes/structure/total_lagrangian_sph/system.jl
@@ -326,7 +326,8 @@ end
     initial_coords = initial_coordinates(system)
     foreach_point_neighbor(system, system, initial_coords, initial_coords,
                            semi) do particle, neighbor, initial_pos_diff, initial_distance
-        # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
+        # Only consider particles with a distance > 0.
+        # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913).
         initial_distance^2 < sqrt(eps(initial_distance^2)) && return
 
         volume = mass[neighbor] / material_density[neighbor]

--- a/src/schemes/structure/total_lagrangian_sph/system.jl
+++ b/src/schemes/structure/total_lagrangian_sph/system.jl
@@ -326,8 +326,8 @@ end
     initial_coords = initial_coordinates(system)
     foreach_point_neighbor(system, system, initial_coords, initial_coords,
                            semi) do particle, neighbor, initial_pos_diff, initial_distance
-        # Only consider particles with a distance > 0.
-        initial_distance < sqrt(eps()) && return
+        # Handle numerical precision issues (see also https://github.com/trixi-framework/TrixiParticles.jl/pull/913)
+        initial_distance^2 < sqrt(eps(initial_distance^2)) && return
 
         volume = mass[neighbor] / material_density[neighbor]
         pos_diff = current_coords(system, particle) - current_coords(system, neighbor)

--- a/test/schemes/structure/total_lagrangian_sph/rhs.jl
+++ b/test/schemes/structure/total_lagrangian_sph/rhs.jl
@@ -85,13 +85,13 @@
 
             TrixiParticles.eachparticle(::MockSystem) = eachparticle
             TrixiParticles.each_integrated_particle(::MockSystem) = each_integrated_particle
+            TrixiParticles.smoothing_length(::MockSystem, _) = eps()
 
             function TrixiParticles.add_acceleration!(_, _, ::MockSystem)
                 return nothing
             end
             TrixiParticles.kernel_deriv(::Val{:mock_smoothing_kernel}, _, _) = kernel_deriv
             TrixiParticles.compact_support(::MockSystem, ::MockSystem) = 1000.0
-            Base.eps(::Type{Val{:mock_smoothing_length}}) = eps()
             function TrixiParticles.current_coords(system::MockSystem, particle)
                 return TrixiParticles.current_coords(initial_coordinates, system, particle)
             end


### PR DESCRIPTION
This PR adapts the threshold used in kernel_grad to eps(h^2) instead of a fixed value `sqrt(eps(typeof(h)))`. This change ensures robust behavior for both single and double precision, especially when using small smoothing lengths or particle spacings. The comparison `distance^2 < eps(h^2)` is preferred over `distance < sqrt(eps(h^2))` for efficiency, since it avoids an unnecessary square root.

Previously, the threshold could be too strict for `Float32`, causing all gradients to be set to zero for small `h`. By using `eps(h^2)`, the threshold automatically adapts to the precision and scale of the simulation.


Additionally, I attempted to address the ugly formatting issue in the rhs:
<img width="1406" height="155" alt="image" src="https://github.com/user-attachments/assets/1ed896a3-bef7-48b1-a037-2d1afe506bc1" />

