### PR TITLE
Remove test set steady state reached (`interval`)

### DIFF
--- a/test/examples/examples_fluid.jl
+++ b/test/examples/examples_fluid.jl
@@ -368,21 +368,6 @@
         @test sol.retcode == ReturnCode.Terminated
     end
 
-    @trixi_testset "fluid/pipe_flow_2d.jl - steady state reached (`interval`)" begin
-        steady_state_reached = SteadyStateReachedCallback(; interval=1, interval_size=5,
-                                                          reltol=1e-3)
-        @trixi_test_nowarn trixi_include(@__MODULE__,
-                                         joinpath(examples_dir(), "fluid",
-                                                  "pipe_flow_2d.jl"),
-                                         open_boundary_model=BoundaryModelCharacteristicsLastiwka(),
-                                         extra_callback=steady_state_reached, dtmax=2e-3,
-                                         tspan=(0.0, 1.5), viscosity_boundary=nothing)
-
-        # Make sure that the simulation is terminated after a reasonable amount of time
-        @test 0.1 < sol.t[end] < 1.0
-        @test sol.retcode == ReturnCode.Terminated
-    end
-
     @trixi_testset "fluid/pipe_flow_3d.jl" begin
         @trixi_test_nowarn trixi_include(@__MODULE__,
                                          joinpath(examples_dir(), "fluid",

--- a/test/examples/gpu.jl
+++ b/test/examples/gpu.jl
@@ -389,26 +389,6 @@ end
             @test 0.1 < sol.t[end] < 1.0
             @test sol.retcode == ReturnCode.Terminated
         end
-
-        @trixi_testset "fluid/pipe_flow_2d.jl - steady state reached (`interval`)" begin
-            steady_state_reached = SteadyStateReachedCallback(; interval=1,
-                                                              interval_size=5,
-                                                              reltol=1.0f-3)
-            @trixi_test_nowarn trixi_include_changeprecision(Float32, @__MODULE__,
-                                                             joinpath(examples_dir(),
-                                                                      "fluid",
-                                                                      "pipe_flow_2d.jl"),
-                                                             extra_callback=steady_state_reached,
-                                                             open_boundary_model=BoundaryModelCharacteristicsLastiwka(),
-                                                             dtmax=2.0f-3,
-                                                             tspan=(0.0f0, 1.5f0),
-                                                             parallelization_backend=Main.parallelization_backend,
-                                                             viscosity_boundary=nothing)
-
-            # Make sure that the simulation is terminated after a reasonable amount of time
-            @test 0.1 < sol.t[end] < 1.0
-            @test sol.retcode == ReturnCode.Terminated
-        end
     end
 
     @testset verbose=true "Structure" begin


### PR DESCRIPTION
Removed tests for the `interval` option in the `SteadyStateReachedCallback`, as they can fail non-deterministically and the behavior depends strongly on the time step size. Using `interval` in this callback is not robust and may lead to unexpected results. The option is now only used in the packing example and will likely be removed from there in the future.