### PR TITLE
Add `OrientedBoundingBox`

### DIFF
--- a/src/TrixiParticles.jl
+++ b/src/TrixiParticles.jl
@@ -95,7 +95,7 @@ export RectangularTank, RectangularShape, SphereShape, ComplexShape
 export ParticlePackingSystem, SignedDistanceField
 export WindingNumberHormann, WindingNumberJacobson
 export VoxelSphere, RoundSphere, reset_wall!, extrude_geometry, load_geometry,
-       sample_boundary, planar_geometry_to_face, OrientedBox
+       sample_boundary, planar_geometry_to_face, OrientedBoundingBox
 export SourceTermDamping
 export ShepardKernelCorrection, KernelCorrection, AkinciFreeSurfaceCorrection,
        GradientCorrection, BlendedGradientCorrection, MixedKernelGradientCorrection

--- a/src/TrixiParticles.jl
+++ b/src/TrixiParticles.jl
@@ -85,8 +85,7 @@ export DensityDiffusionMolteniColagrossi, DensityDiffusionFerrari, DensityDiffus
 export tensile_instability_control
 export BoundaryModelMonaghanKajtar, BoundaryModelDummyParticles, AdamiPressureExtrapolation,
        PressureMirroring, PressureZeroing, BoundaryModelCharacteristicsLastiwka,
-       BoundaryModelMirroringTafuni,
-       BernoulliPressureExtrapolation
+       BoundaryModelMirroringTafuni, BernoulliPressureExtrapolation
 export FirstOrderMirroring, ZerothOrderMirroring, SimpleMirroring
 export HertzContactModel, LinearContactModel
 export PrescribedMotion
@@ -96,7 +95,7 @@ export RectangularTank, RectangularShape, SphereShape, ComplexShape
 export ParticlePackingSystem, SignedDistanceField
 export WindingNumberHormann, WindingNumberJacobson
 export VoxelSphere, RoundSphere, reset_wall!, extrude_geometry, load_geometry,
-       sample_boundary, planar_geometry_to_face
+       sample_boundary, planar_geometry_to_face, OrientedBox
 export SourceTermDamping
 export ShepardKernelCorrection, KernelCorrection, AkinciFreeSurfaceCorrection,
        GradientCorrection, BlendedGradientCorrection, MixedKernelGradientCorrection

--- a/src/preprocessing/geometries/geometries.jl
+++ b/src/preprocessing/geometries/geometries.jl
@@ -92,7 +92,7 @@ face, face_normal = planar_geometry_to_face(planar_geometry)
 function planar_geometry_to_face(planar_geometry::TriangleMesh)
     face_normal = normalize(sum(planar_geometry.face_normals) / nfaces(planar_geometry))
 
-    face_vertices = oriented_bounding_box(stack(planar_geometry.vertices))
+    face_vertices, _, _ = oriented_bounding_box(stack(planar_geometry.vertices))
 
     # Vectors spanning the face
     edge1 = face_vertices[:, 2] - face_vertices[:, 1]
@@ -120,8 +120,202 @@ function oriented_bounding_box(point_cloud)
     min_corner = minimum(aligned_coords, dims=2)
     max_corner = maximum(aligned_coords, dims=2)
 
-    face_vertices = hcat(min_corner, max_corner,
-                         [min_corner[1], max_corner[2], min_corner[3]])
+    rect_coords = hcat(min_corner, max_corner,
+                       [min_corner[1], max_corner[2], min_corner[3]])
 
-    return eigen_vectors * face_vertices .+ means
+    rotated_rect_coords = eigen_vectors * rect_coords .+ means
+
+    return rotated_rect_coords, eigen_vectors, (min_corner, max_corner)
+end
+
+"""
+    OrientedBox(; box_origin, orientation_vector, edge_lengths::Tuple)
+    OrientedBox(geometry::TrixiParticles.TriangleMesh; scale::Real=1)
+
+Constructor for a parallelogram spanned by two orthogonal edge vectors,
+a parallelepiped spanned by three orthogonal edge vectors,
+or a parallelepiped enclosing a 3D geometry.
+
+# Arguments
+- `geometry`: Geometry returned by [`load_geometry`](@ref).
+
+# Keywords
+- `box_origin`: The origin corner of the box.
+- `orientation_vector`: A vector describing the main direction of the box.
+- `edge_lengths::Tuple`: The lengths of the edges of the box:
+                            - In 2D: `(length_x, length_y)`
+                            - In 3D: `(length_x, length_y, length_z)`
+
+# Examples
+```jldoctest; output=false
+# 2D
+OrientedBox(
+    box_origin = [0.0, 0.0],
+    orientation_vector = [1.0, 1.0],
+    edge_lengths = (2.0, 1.0)
+)
+
+# 3D
+OrientedBox(
+    box_origin = [0.5, -0.2, 0.0],
+    orientation_vector = [0.0, 0.0, 1.0],
+    edge_lengths = (1.0, 2.0, 3.0)
+)
+
+# output
+┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ OrientedBox (3D)                                                                                 │
+│ ════════════════                                                                                 │
+│ zone origin: ……………………………………………… [0.5, -0.2, 0.0]                                                 │
+│ edge lengths: …………………………………………… (1.0, 2.0, 3.0)                                                  │
+└──────────────────────────────────────────────────────────────────────────────────────────────────┘
+"""
+struct OrientedBox{NDIMS, ELTYPE <: Real, SV}
+    box_origin       :: SVector{NDIMS, ELTYPE}
+    spanning_vectors :: SV
+end
+
+# Constructor with orientation vector (from box_origin to opposite corner)
+function OrientedBox(; box_origin, orientation_vector, edge_lengths::Tuple)
+    NDIMS = length(box_origin)
+
+    @assert length(orientation_vector) == NDIMS
+    @assert length(edge_lengths) == NDIMS
+
+    # Normalize the orientation vector to get the primary direction
+    primary_direction = normalize(orientation_vector)
+
+    # Create orthogonal basis vectors
+    R = orientation_matrix(primary_direction, edge_lengths)
+
+    spanning_vectors = ntuple(i -> SVector{NDIMS}(R[:, i] * edge_lengths[i]),
+                              length(edge_lengths))
+
+    return OrientedBox(SVector{NDIMS}(box_origin), spanning_vectors)
+end
+
+function OrientedBox(geometry::TriangleMesh)
+    point_cloud = stack(geometry.vertices)
+    vertices, eigen_vectors, (min_corner, max_corner) = oriented_bounding_box(point_cloud)
+
+    # Use the first vertex as box origin (bottom-left-front corner)
+    box_origin = SVector{3}(vertices[:, 1])
+
+    # Calculate edge lengths from min/max corners
+    edge_lengths = max_corner - min_corner
+
+    # Create spanning vectors using the eigen vectors scaled by edge lengths
+    spanning_vectors = ntuple(i -> SVector{3}(eigen_vectors[:, i] * edge_lengths[i]), 3)
+
+    return OrientedBox(box_origin, spanning_vectors)
+end
+
+@inline Base.ndims(::OrientedBox{NDIMS}) where {NDIMS} = NDIMS
+
+function Base.show(io::IO, ::MIME"text/plain", box::OrientedBox)
+    @nospecialize box # reduce precompilation time
+
+    if get(io, :compact, false)
+        show(io, box)
+    else
+        summary_header(io, "OrientedBox ($(ndims(box))D)")
+        summary_line(io, "box origin", box.box_origin)
+        summary_line(io, "edge lengths", norm.(box.spanning_vectors))
+        summary_footer(io)
+    end
+end
+
+function orientation_matrix(primary_direction, ::NTuple{2})
+    perpendicular = [-primary_direction[2], primary_direction[1]]
+    return hcat(primary_direction, perpendicular)
+end
+
+function orientation_matrix(primary_direction, ::NTuple{3})
+    # Find two orthogonal vectors to the primary direction
+    # Choose a vector that's not parallel to primary_direction
+    temp = abs(primary_direction[1]) < 0.9 ? [1.0, 0.0, 0.0] : [0.0, 1.0, 0.0]
+
+    # Gram-Schmidt orthogonalization
+    v2 = temp - dot(temp, primary_direction) * primary_direction
+    v2 = normalize(v2)
+    v3 = cross(primary_direction, v2)
+
+    return hcat(primary_direction, v2, v3)
+end
+
+function is_in_oriented_box(coordinates::AbstractArray, box)
+    is_in_box = fill(false, nparticles(initial_condition))
+    @threaded default_backend(coordinates) for particle in eachparticle(initial_condition)
+        particle_coords = current_coords(coordinates, box, particle)
+        is_in_box[particle] = is_in_oriented_box(particle_coords, box)
+    end
+
+    return findall(is_in_box)
+end
+
+@inline function is_in_oriented_box(particle_coords::SVector{NDIMS}, box) where {NDIMS}
+    (; spanning_vectors, zone_origin) = box
+    relative_position = particle_coords - zone_origin
+
+    for dim in 1:NDIMS
+        span_dim = spanning_vectors[dim]
+        # Checks whether the projection of the particle position
+        # falls within the range of the zone
+        if !(0 <= dot(relative_position, span_dim) <= dot(span_dim, span_dim))
+
+            # Particle is not in box
+            return false
+        end
+    end
+
+    # Particle is in box
+    return true
+end
+
+@inline function Base.intersect(initial_condition::InitialCondition, boxes::OrientedBox...)
+    (; coordinates, density, mass, velocity, pressure, particle_spacing) = initial_condition
+    box = first(boxes)
+
+    if ndims(box) != ndims(initial_condition)
+        throw(ArgumentError("all passed `OrientedBox`s must have the same dimensionality as the initial condition"))
+    end
+
+    keep_indices = fill(false, nparticles(initial_condition))
+    @threaded default_backend(coordinates) for particle in eachparticle(initial_condition)
+        particle_coords = current_coords(coordinates, initial_condition, particle)
+
+        keep_indices[particle] = is_in_oriented_box(particle_coords, box)
+    end
+
+    result = InitialCondition(; coordinates=coordinates[:, keep_indices],
+                              density=density[keep_indices], mass=mass[keep_indices],
+                              velocity=velocity[:, keep_indices],
+                              pressure=pressure[keep_indices],
+                              particle_spacing)
+
+    return intersect(result, Base.tail(boxes)...)
+end
+
+@inline function Base.setdiff(initial_condition::InitialCondition, boxes::OrientedBox...)
+    (; coordinates, density, mass, velocity, pressure, particle_spacing) = initial_condition
+    box = first(boxes)
+
+    if ndims(box) != ndims(initial_condition)
+        throw(ArgumentError("all passed `OrientedBox`s must have the same dimensionality as the initial condition"))
+    end
+
+    keep_indices = fill(false, nparticles(initial_condition))
+    @threaded default_backend(coordinates) for particle in eachparticle(initial_condition)
+        particle_coords = current_coords(coordinates, initial_condition, particle)
+
+        keep_indices[particle] = !is_in_oriented_box(particle_coords, box)
+    end
+
+    result = InitialCondition(; coordinates=coordinates[:, keep_indices],
+                              density=density[keep_indices], mass=mass[keep_indices],
+                              velocity=velocity[:, keep_indices],
+                              pressure=pressure[keep_indices],
+                              particle_spacing)
+
+    return setdiff(result, Base.tail(boxes)...)
 end

--- a/src/visualization/recipes_plots.jl
+++ b/src/visualization/recipes_plots.jl
@@ -170,3 +170,41 @@ RecipesBase.@recipe function f(geometry::Polygon)
         return (x, y)
     end
 end
+
+RecipesBase.@recipe function f(box::OrientedBox{2})
+    # Get the box origin and spanning vectors
+    origin = box.box_origin
+    v1, v2 = box.spanning_vectors
+
+    # Calculate all 4 corners of the rectangle
+    # Corner 1: origin
+    # Corner 2: origin + v1
+    # Corner 3: origin + v1 + v2 (diagonal corner)
+    # Corner 4: origin + v2
+    corners = hcat(origin,
+                   origin + v1,
+                   origin + v1 + v2,
+                   origin + v2,
+                   origin)  # Close the rectangle by returning to start
+
+    x = corners[1, :]
+    y = corners[2, :]
+
+    aspect_ratio --> :equal
+    grid --> false
+
+    # First plot the vertices as a scatter plot
+    @series begin
+        seriestype --> :scatter
+        return (x, y)
+    end
+
+    # Now plot the edges as a line plot
+    @series begin
+        # Ignore series in legend and color cycling. Note that `:=` forces the attribute,
+        # whereas `-->` would only set it if it is not already set.
+        primary := false
+
+        return (x, y)
+    end
+end

--- a/src/visualization/recipes_plots.jl
+++ b/src/visualization/recipes_plots.jl
@@ -171,7 +171,7 @@ RecipesBase.@recipe function f(geometry::Polygon)
     end
 end
 
-RecipesBase.@recipe function f(box::OrientedBox{2})
+RecipesBase.@recipe function f(box::OrientedBoundingBox{2})
     # Get the box origin and spanning vectors
     origin = box.box_origin
     v1, v2 = box.spanning_vectors


### PR DESCRIPTION
# 2D
```julia
using TrixiParticles
using Plots

data_dir = pkgdir(TrixiParticles, "examples", "preprocessing", "data")
geometry = load_geometry(joinpath(data_dir, "potato.asc"))

box_1 = OrientedBox(geometry)
box_2 = OrientedBox(geometry, local_axis_scale=(1.5, 2))
box_3 = OrientedBox(geometry, local_axis_scale=(3, 0.5))

plot(geometry, label="geometry", color=:black)
plot!(box_1, label="box: no scaling")
plot!(box_2, label="box: local_axis_scale=(1.5, 2)")
plot!(box_3, label="box: local_axis_scale=(3, 0.5)")
``` 
<img width="487" height="326" alt="image" src="https://github.com/user-attachments/assets/1f3b973a-8ec8-4675-917d-f16d63d7224a" />

# 3D
(hard to visualize but it's working)
```julia
file = pkgdir(TrixiParticles, "test", "preprocessing", "data")
geometry = load_geometry(joinpath(file, "inflow.stl"))
box_3d = OrientedBoundingBox(geometry)

trixi2vtk(stack(box_3d.spanning_vectors) .+ box_3d.box_origin)
```

<img width="763" height="708" alt="image" src="https://github.com/user-attachments/assets/256ae046-1012-4445-9541-95ba5eac1974" />
