### PR TITLE
Remove `--first-parent` from git describe

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -138,7 +138,7 @@ function compute_git_hash()
     end
 
     try
-        git_cmd = Cmd(`git describe --tags --always --first-parent --dirty`,
+        git_cmd = Cmd(`git describe --tags --always --dirty`,
                       dir=pkg_directory)
         return string(readchomp(git_cmd))
     catch e


### PR DESCRIPTION
I don't remember why I added this option. With the option, I get `v0.3.1-...` on branches that contain the latest main.