### PR TITLE
Fix overhead for empty update callback

### DIFF
--- a/src/callbacks/update.jl
+++ b/src/callbacks/update.jl
@@ -74,6 +74,11 @@ function (update_callback!::UpdateCallback)(integrator)
     semi = integrator.p
     v_ode, u_ode = integrator.u.x
 
+    # Tell OrdinaryDiffEq that `integrator.u` has NOT been modified.
+    # This will be set to `true` in any of the update functions below that modify
+    # either `v_ode` or `u_ode`.
+    u_modified!(integrator, false)
+
     @trixi_timeit timer() "update callback" begin
         # Update quantities that are stored in the systems. These quantities (e.g. pressure)
         # still have the values from the last stage of the previous step if not updated here.
@@ -84,7 +89,7 @@ function (update_callback!::UpdateCallback)(integrator)
 
         # Update open boundaries first, since particles might be activated or deactivated
         @trixi_timeit timer() "update open boundary" foreach_system(semi) do system
-            update_open_boundary_eachstep!(system, v_ode, u_ode, semi, t)
+            update_open_boundary_eachstep!(system, v_ode, u_ode, semi, t, integrator)
         end
 
         @trixi_timeit timer() "update particle packing" foreach_system(semi) do system
@@ -93,17 +98,14 @@ function (update_callback!::UpdateCallback)(integrator)
 
         # This is only used by the particle packing system and should be removed in the future
         @trixi_timeit timer() "update TVF" foreach_system(semi) do system
-            update_transport_velocity!(system, v_ode, semi)
+            update_transport_velocity!(system, v_ode, semi, integrator)
         end
 
         @trixi_timeit timer() "particle shifting" foreach_system(semi) do system
             particle_shifting_from_callback!(u_ode, shifting_technique(system), system,
-                                             v_ode, semi, integrator.dt)
+                                             v_ode, semi, integrator)
         end
     end
-
-    # Tell OrdinaryDiffEq that `u` has been modified
-    u_modified!(integrator, true)
 
     return integrator
 end

--- a/src/schemes/boundary/open_boundary/system.jl
+++ b/src/schemes/boundary/open_boundary/system.jl
@@ -292,7 +292,7 @@ end
 
 # This function is called by the `UpdateCallback`, as the integrator array might be modified
 function update_open_boundary_eachstep!(system::OpenBoundarySystem, v_ode, u_ode,
-                                        semi, t)
+                                        semi, t, integrator)
     (; boundary_model) = system
 
     u = wrap_u(u_ode, system, semi)
@@ -305,10 +305,13 @@ function update_open_boundary_eachstep!(system::OpenBoundarySystem, v_ode, u_ode
         update_boundary_quantities!(system, boundary_model, v, u, v_ode, u_ode, semi, t)
     end
 
+    # Tell OrdinaryDiffEq that `integrator.u` has been modified
+    u_modified!(integrator, true)
+
     return system
 end
 
-update_open_boundary_eachstep!(system, v_ode, u_ode, semi, t) = system
+update_open_boundary_eachstep!(system, v_ode, u_ode, semi, t, integrator) = system
 
 function check_domain!(system, v, u, v_ode, u_ode, semi)
     (; boundary_zones, boundary_candidates, fluid_candidates, fluid_system) = system


### PR DESCRIPTION
The update callback is always setting `u_modified` to true, forcing recomputation of FSAL stages in the time integrator, even if no update was performed. This overhead is not clear from the timer output, as "update callback" only shows up with a small percentage. The overhead comes from the fact that more RHS calls are required, which can be seen in the "ncalls" of "kick!" and "drift!".

No `UpdateCallback`: 979 total time steps, 4.9k RHS evaluations.
```
──────────────────────────────────────────────────────────────────────────────────────────
           TrixiParticles.jl                     Time                    Allocations      
                                        ───────────────────────   ────────────────────────
           Tot / % measured:                 303ms /  87.3%           40.8MiB /  92.0%    

Section                         ncalls     time    %tot     avg     alloc    %tot      avg
──────────────────────────────────────────────────────────────────────────────────────────
kick!                            4.90k    256ms   96.9%  52.3μs   32.7MiB   87.1%  6.84KiB
drift!                           4.90k   8.31ms    3.1%  1.70μs   4.86MiB   12.9%  1.02KiB
──────────────────────────────────────────────────────────────────────────────────────────
```
Empty (no open boundaries, packing or shifting used) `UpdateCallback` on main: 979 total time steps, 5.82, RHS evaluations.
```
──────────────────────────────────────────────────────────────────────────────────────────
           TrixiParticles.jl                     Time                    Allocations      
                                        ───────────────────────   ────────────────────────
           Tot / % measured:                 383ms /  89.9%           51.4MiB /  93.7%    

Section                         ncalls     time    %tot     avg     alloc    %tot      avg
──────────────────────────────────────────────────────────────────────────────────────────
kick!                            5.82k    305ms   88.4%  52.4μs   38.9MiB   80.7%  6.84KiB
update callback                    923   29.1ms    8.4%  31.5μs   3.51MiB    7.3%  3.89KiB
  update systems and nhs           923   28.8ms    8.3%  31.2μs   3.51MiB    7.3%  3.89KiB
  ~update callback~                923    234μs    0.1%   253ns   1.84KiB    0.0%    2.05B
  update particle packing          923   11.7μs    0.0%  12.6ns     0.00B    0.0%    0.00B
  update open boundary             923   11.5μs    0.0%  12.4ns     0.00B    0.0%    0.00B
  update TVF                       923   10.8μs    0.0%  11.7ns     0.00B    0.0%    0.00B
  particle shifting                923   9.55μs    0.0%  10.3ns     0.00B    0.0%    0.00B
drift!                           5.82k   11.0ms    3.2%  1.88μs   5.77MiB   12.0%  1.02KiB
──────────────────────────────────────────────────────────────────────────────────────────
```
Empty `UpdateCallback` with this PR: 979 total time steps, 4.9k RHS evaluations.
```
──────────────────────────────────────────────────────────────────────────────────────────
           TrixiParticles.jl                     Time                    Allocations      
                                        ───────────────────────   ────────────────────────
           Tot / % measured:                 330ms /  83.8%           44.4MiB /  92.6%    

Section                         ncalls     time    %tot     avg     alloc    %tot      avg
──────────────────────────────────────────────────────────────────────────────────────────
kick!                            4.90k    240ms   86.8%  49.0μs   32.7MiB   79.6%  6.84KiB
update callback                    923   27.5ms   10.0%  29.8μs   3.51MiB    8.5%  3.89KiB
  update systems and nhs           923   27.2ms    9.9%  29.5μs   3.51MiB    8.5%  3.89KiB
  ~update callback~                923    241μs    0.1%   261ns   1.84KiB    0.0%    2.05B
  update TVF                       923   11.8μs    0.0%  12.7ns     0.00B    0.0%    0.00B
  particle shifting                923   10.7μs    0.0%  11.6ns     0.00B    0.0%    0.00B
  update particle packing          923   10.4μs    0.0%  11.3ns     0.00B    0.0%    0.00B
  update open boundary             923   10.4μs    0.0%  11.3ns     0.00B    0.0%    0.00B
drift!                           4.90k   9.03ms    3.3%  1.84μs   4.86MiB   11.8%  1.02KiB
──────────────────────────────────────────────────────────────────────────────────────────
```