### PR TITLE
Add IntervalSets to dep and compat sections

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,6 @@ FastPow = "c0e83750-1142-43a8-81cf-6c956b72b4d1"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
-IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -35,6 +34,7 @@ TrixiBase = "9a0f1c46-06d5-4909-a5a3-ce25d3fa3284"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [weakdeps]
+IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 


### PR DESCRIPTION
Similar to https://github.com/trixi-framework/Trixi.jl/pull/2649 but since the fix will be breaking for IntervalSets we will allow future versions with the fix as well


fixes #978 