### PR TITLE
Ramp shifting velocity near the free surface

### DIFF
--- a/src/schemes/boundary/open_boundary/system.jl
+++ b/src/schemes/boundary/open_boundary/system.jl
@@ -539,7 +539,7 @@ end
 
         if dist_free_surface < compact_support(fluid_system, fluid_system)
             # Ramp shifting velocity near the free surface using a kernel-weighted transition.
-            # According to our experiment, alternative approaches lead to particle disorder:
+            # According to our experiments, the proposed alternative approaches lead to particle disorder:
             # - Sun et al. 2017: only use surface-tangential component
             # - Zhang et al. 2025: disable shifting entirely
             kernel_max = smoothing_kernel(system, 0, particle)


### PR DESCRIPTION
This is a better solution for the issue described in #998. As we can see in the figure below, particles remain ordered with this PR (right panel), while the particles in the left panel (#998) begin to leave the zone.

Do we need the PR #998 anyway? @efaulhaber @svchb ?

<img width="1542" height="757" alt="image" src="https://github.com/user-attachments/assets/f96e0f66-bb4f-4771-820a-495278b85204" />

Note that this reduces the runtime of a 3 sec simulation by 2.4x because less time steps are required.
For 3 sec sim. time:
PR #998 | This PR
---|----
  #timesteps 89950 | #timesteps 48750
run time 18.18 h | run time 7.5h 




Also note the boundary pressure:
PR #998 | This PR
----------|-------
<img width="997" height="735" alt="image" src="https://github.com/user-attachments/assets/75f9a974-faf5-4b5e-8f45-737aae878b26" /> | <img width="997" height="735" alt="image" src="https://github.com/user-attachments/assets/fe71a8c5-ba6d-4d46-9b18-91bad5d4694b" />


