### PR TITLE
Use `ThreadedBroadcastArray` on GPUs

### DIFF
--- a/src/TrixiParticles.jl
+++ b/src/TrixiParticles.jl
@@ -12,7 +12,7 @@ using DiffEqCallbacks: PeriodicCallback, PeriodicCallbackAffect, PresetTimeCallb
 using FastPow: @fastpow
 using FileIO: FileIO
 using ForwardDiff: ForwardDiff
-using GPUArraysCore: AbstractGPUArray
+using GPUArraysCore: GPUArraysCore
 using JSON: JSON
 using KernelAbstractions: KernelAbstractions, @kernel, @index
 using LinearAlgebra: norm, normalize, cross, dot, I, tr, inv, pinv, det

--- a/src/general/gpu.jl
+++ b/src/general/gpu.jl
@@ -1,3 +1,7 @@
+const AbstractGPUArray = Union{GPUArraysCore.AbstractGPUArray,
+                               ThreadedBroadcastArray{<:Any, <:Any,
+                                                      <:GPUArraysCore.AbstractGPUArray}}
+
 # Adapt.jl provides a function `adapt(to, x)`, which adapts a value `x` to `to`.
 # In practice, this means that we can use `adapt(CuArray, system)` to adapt a system to
 # the `CuArray` type.

--- a/src/general/semidiscretization.jl
+++ b/src/general/semidiscretization.jl
@@ -315,7 +315,7 @@ function semidiscretize(semi, tspan; reset_threads=true)
     u0_ode_ = allocate(semi.parallelization_backend, cELTYPE, sum(sizes_u))
     v0_ode_ = allocate(semi.parallelization_backend, ELTYPE, sum(sizes_v))
 
-    # if semi.parallelization_backend isa KernelAbstractions.Backend
+    # if semi.parallelization_backend isa KernelAbstractions.GPU
     #     u0_ode = u0_ode_
     #     v0_ode = v0_ode_
     # else

--- a/src/util.jl
+++ b/src/util.jl
@@ -238,13 +238,13 @@ end
 Base.copyto!(dest::ThreadedBroadcastArray, indices1::CartesianIndices, src::AbstractArray, indices2::CartesianIndices) =
     copyto!(parent(dest), indices1, src, indices2)
 
-function Base.mapreduce(f, op, A::ThreadedBroadcastArray{<:Any, <:Any, <:AbstractGPUArray},
+function Base.mapreduce(f, op, A::ThreadedBroadcastArray{<:Any, <:Any, <:GPUArraysCore.AbstractGPUArray},
                         As::Union{AbstractArray, Broadcast.Broadcasted}...;
                         dims=:, init=nothing)
     mapreduce(f, op, parent(A), As...; dims=dims, init=init)
 end
 
-function Base.any(f::Function, A::ThreadedBroadcastArray{<:Any, <:Any, <:AbstractGPUArray})
+function Base.any(f::Function, A::ThreadedBroadcastArray{<:Any, <:Any, <:GPUArraysCore.AbstractGPUArray})
     any(f, parent(A))
 end
 


### PR DESCRIPTION
#1031:
```
──────────────────────────────────────────────────────────────────────────────────────────
           TrixiParticles.jl                     Time                    Allocations      
                                        ───────────────────────   ────────────────────────
           Tot / % measured:                 24.0s /  99.9%           1.13GiB /  99.8%    

Section                         ncalls     time    %tot     avg     alloc    %tot      avg
──────────────────────────────────────────────────────────────────────────────────────────
kick!                              191    17.7s   74.0%  92.8ms    129MiB   11.1%   689KiB
  system interaction               191    13.8s   57.7%  72.3ms   30.0MiB    2.6%   161KiB
    fluid1-boundary2               191    5.11s   21.3%  26.7ms   8.96MiB    0.8%  48.0KiB
    fluid1-structure3              191    4.77s   19.9%  25.0ms   11.4MiB    1.0%  61.2KiB
    fluid1-fluid1                  191    3.92s   16.4%  20.5ms   7.95MiB    0.7%  42.6KiB
    ~system interaction~           191   8.18ms    0.0%  42.8μs   1.72MiB    0.1%  9.22KiB
    structure3-fluid1              191   27.3μs    0.0%   143ns     0.00B    0.0%    0.00B
    boundary2-structure3           191   13.3μs    0.0%  69.5ns     0.00B    0.0%    0.00B
    boundary2-fluid1               191   12.4μs    0.0%  64.8ns     0.00B    0.0%    0.00B
    boundary2-boundary2            191   12.0μs    0.0%  62.7ns     0.00B    0.0%    0.00B
    structure3-structure3          191   11.9μs    0.0%  62.2ns     0.00B    0.0%    0.00B
    structure3-boundary2           191   9.76μs    0.0%  51.1ns     0.00B    0.0%    0.00B
  update systems and nhs           191    3.86s   16.1%  20.2ms   53.7MiB    4.6%   288KiB
    update TLSPH positions         191    3.58s   15.0%  18.8ms   2.24MiB    0.2%  12.0KiB
    update nhs                     191    137ms    0.6%   719μs   9.88MiB    0.9%  53.0KiB
    compute boundary pressure      382   50.9ms    0.2%   133μs   21.7MiB    1.9%  58.1KiB
    ~update systems and nhs~       191   28.2ms    0.1%   148μs   3.25MiB    0.3%  17.4KiB
    stress tensor                  191   25.0ms    0.1%   131μs   7.20MiB    0.6%  38.6KiB
    inverse state equation         382   21.1ms    0.1%  55.2μs   5.07MiB    0.4%  13.6KiB
    apply prescribed motion        191   12.6ms    0.1%  65.8μs   4.39MiB    0.4%  23.5KiB
    update density diffusion       191   14.4μs    0.0%  75.6ns     0.00B    0.0%    0.00B
  source terms                     191   49.8ms    0.2%   261μs   44.6MiB    3.9%   239KiB
  reset ∂v/∂t                      191   1.97ms    0.0%  10.3μs    236KiB    0.0%  1.23KiB
  ~kick!~                          191   1.69ms    0.0%  8.83μs   1.55KiB    0.0%    8.29B
split integration                   38    3.54s   14.8%  93.2ms   0.95GiB   83.6%  25.5MiB
  solve                             37    3.49s   14.6%  94.2ms   0.94GiB   82.7%  25.9MiB
    system interaction           3.70k    1.15s    4.8%   310μs    320MiB   27.6%  88.5KiB
      structure3-fluid1          3.70k    750ms    3.1%   203μs    221MiB   19.0%  61.1KiB
      structure3-structure3      3.70k    343ms    1.4%  92.7μs   87.9MiB    7.6%  24.3KiB
      ~system interaction~       3.70k   53.8ms    0.2%  14.6μs   11.1MiB    1.0%  3.07KiB
      structure3-boundary2       3.70k    188μs    0.0%  50.7ns     0.00B    0.0%    0.00B
    ~solve~                         37    910ms    3.8%  24.6ms   56.9MiB    4.9%  1.54MiB
    update systems               3.70k    843ms    3.5%   228μs    272MiB   23.5%  75.3KiB
      stress tensor              3.70k    442ms    1.8%   119μs    139MiB   12.0%  38.6KiB
      apply prescribed motion    3.70k    232ms    1.0%  62.7μs   85.0MiB    7.3%  23.5KiB
      update TLSPH positions     3.70k    134ms    0.6%  36.2μs   43.4MiB    3.7%  12.0KiB
      ~update systems~           3.70k   34.6ms    0.1%  9.36μs   4.52MiB    0.4%  1.25KiB
    drift!                       3.70k    322ms    1.3%  87.0μs    155MiB   13.4%  42.9KiB
      velocity                   3.70k    272ms    1.1%  73.5μs    151MiB   13.0%  41.7KiB
      reset ∂u/∂t                3.70k   34.7ms    0.1%  9.37μs   4.40MiB    0.4%  1.22KiB
      ~drift!~                   3.70k   15.5ms    0.1%  4.18μs      976B    0.0%    0.26B
    source terms                 3.70k    232ms    1.0%  62.8μs    151MiB   13.0%  41.7KiB
    reset ∂v/∂t                  3.70k   32.2ms    0.1%  8.69μs   4.40MiB    0.4%  1.22KiB
  update systems and nhs            37   54.0ms    0.2%  1.46ms   10.4MiB    0.9%   288KiB
    update nhs                      37   26.2ms    0.1%   709μs   1.91MiB    0.2%  53.0KiB
    compute boundary pressure       74   9.69ms    0.0%   131μs   4.20MiB    0.4%  58.1KiB
    ~update systems and nhs~        37   5.31ms    0.0%   144μs    646KiB    0.1%  17.5KiB
    stress tensor                   37   4.81ms    0.0%   130μs   1.39MiB    0.1%  38.6KiB
    inverse state equation          74   4.03ms    0.0%  54.4μs   0.98MiB    0.1%  13.6KiB
    apply prescribed motion         37   2.11ms    0.0%  57.1μs    870KiB    0.1%  23.5KiB
    update TLSPH positions          37   1.78ms    0.0%  48.0μs    444KiB    0.0%  12.0KiB
    update density diffusion        37   4.90μs    0.0%   132ns     0.00B    0.0%    0.00B
  init                               1   1.38ms    0.0%  1.38ms    281KiB    0.0%   281KiB
  copy back                         37   1.30ms    0.0%  35.1μs    191KiB    0.0%  5.17KiB
  ~split integration~               38    294μs    0.0%  7.73μs   1.55KiB    0.0%    41.7B
update callback                     38    2.60s   10.8%  68.3ms   16.5MiB    1.4%   444KiB
  ~update callback~                 38    2.53s   10.6%  66.7ms   5.79MiB    0.5%   156KiB
  update systems and nhs            38   62.2ms    0.3%  1.64ms   10.7MiB    0.9%   288KiB
  apply particle shifting           38   4.74μs    0.0%   125ns     0.00B    0.0%    0.00B
drift!                             191   87.6ms    0.4%   459μs   44.9MiB    3.9%   241KiB
  velocity                         191   84.1ms    0.4%   441μs   44.6MiB    3.9%   239KiB
  reset ∂u/∂t                      191   2.53ms    0.0%  13.3μs    236KiB    0.0%  1.23KiB
  ~drift!~                         191    971μs    0.0%  5.08μs      976B    0.0%    5.11B
calculate dt                         1   2.08μs    0.0%  2.08μs     0.00B    0.0%    0.00B
──────────────────────────────────────────────────────────────────────────────────────────
```
#1031 + this PR:
```
──────────────────────────────────────────────────────────────────────────────────────────
           TrixiParticles.jl                     Time                    Allocations      
                                        ───────────────────────   ────────────────────────
           Tot / % measured:                 17.7s /  99.4%           1.05GiB /  99.7%    

Section                         ncalls     time    %tot     avg     alloc    %tot      avg
──────────────────────────────────────────────────────────────────────────────────────────
kick!                              191    12.9s   73.4%  67.8ms    130MiB   12.2%   699KiB
  system interaction               191    12.6s   71.5%  66.0ms   30.6MiB    2.9%   164KiB
    fluid1-boundary2               191    4.45s   25.2%  23.3ms   9.17MiB    0.9%  49.2KiB
    fluid1-structure3              191    4.31s   24.4%  22.5ms   11.4MiB    1.1%  61.4KiB
    fluid1-fluid1                  191    3.84s   21.8%  20.1ms   8.22MiB    0.8%  44.1KiB
    ~system interaction~           191   8.11ms    0.0%  42.4μs   1.72MiB    0.2%  9.22KiB
    boundary2-fluid1               191   16.2μs    0.0%  84.9ns     0.00B    0.0%    0.00B
    structure3-structure3          191   15.6μs    0.0%  81.9ns     0.00B    0.0%    0.00B
    boundary2-boundary2            191   12.0μs    0.0%  62.8ns     0.00B    0.0%    0.00B
    structure3-fluid1              191   11.7μs    0.0%  61.2ns     0.00B    0.0%    0.00B
    boundary2-structure3           191   11.1μs    0.0%  58.1ns     0.00B    0.0%    0.00B
    structure3-boundary2           191   9.63μs    0.0%  50.4ns     0.00B    0.0%    0.00B
  update systems and nhs           191    279ms    1.6%  1.46ms   54.5MiB    5.1%   292KiB
    update nhs                     191    136ms    0.8%   712μs   10.0MiB    0.9%  53.5KiB
    compute boundary pressure      382   50.9ms    0.3%   133μs   22.3MiB    2.1%  59.8KiB
    ~update systems and nhs~       191   27.6ms    0.2%   144μs   3.26MiB    0.3%  17.5KiB
    stress tensor                  191   24.6ms    0.1%   129μs   7.20MiB    0.7%  38.6KiB
    inverse state equation         382   21.3ms    0.1%  55.6μs   5.11MiB    0.5%  13.7KiB
    apply prescribed motion        191   10.7ms    0.1%  56.0μs   4.39MiB    0.4%  23.5KiB
    update TLSPH positions         191   7.65ms    0.0%  40.0μs   2.24MiB    0.2%  12.0KiB
    update density diffusion       191   24.4μs    0.0%   128ns     0.00B    0.0%    0.00B
  source terms                     191   50.1ms    0.3%   262μs   45.0MiB    4.2%   241KiB
  reset ∂v/∂t                      191   7.15ms    0.0%  37.4μs    337KiB    0.0%  1.77KiB
  ~kick!~                          191   1.64ms    0.0%  8.58μs   1.55KiB    0.0%    8.29B
split integration                   38    2.84s   16.1%  74.7ms    879MiB   82.1%  23.1MiB
  solve                             37    2.78s   15.8%  75.2ms    868MiB   81.0%  23.4MiB
    system interaction           3.70k    1.17s    6.6%   316μs    309MiB   28.8%  85.4KiB
      structure3-fluid1          3.70k    744ms    4.2%   201μs    216MiB   20.1%  59.8KiB
      structure3-structure3      3.70k    375ms    2.1%   101μs   86.6MiB    8.1%  24.0KiB
      ~system interaction~       3.70k   48.2ms    0.3%  13.0μs   6.01MiB    0.6%  1.66KiB
      structure3-boundary2       3.70k    180μs    0.0%  48.6ns     0.00B    0.0%    0.00B
    update systems               3.70k    925ms    5.2%   250μs    267MiB   24.9%  73.9KiB
      stress tensor              3.70k    557ms    3.2%   150μs    139MiB   13.0%  38.6KiB
      apply prescribed motion    3.70k    198ms    1.1%  53.5μs   85.0MiB    7.9%  23.5KiB
      update TLSPH positions     3.70k    143ms    0.8%  38.7μs   42.5MiB    4.0%  11.8KiB
      ~update systems~           3.70k   27.3ms    0.2%  7.37μs   1.25KiB    0.0%    0.35B
    drift!                       3.70k    289ms    1.6%  78.2μs    144MiB   13.5%  39.9KiB
      velocity                   3.70k    271ms    1.5%  73.1μs    144MiB   13.5%  39.9KiB
      ~drift!~                   3.70k   15.2ms    0.1%  4.12μs      976B    0.0%    0.26B
      reset ∂u/∂t                3.70k   3.52ms    0.0%   950ns     0.00B    0.0%    0.00B
    source terms                 3.70k    221ms    1.3%  59.8μs    144MiB   13.5%  39.9KiB
    ~solve~                         37    176ms    1.0%  4.74ms   3.83MiB    0.4%   106KiB
    reset ∂v/∂t                  3.70k   2.20ms    0.0%   595ns     0.00B    0.0%    0.00B
  update systems and nhs            37   53.9ms    0.3%  1.46ms   10.6MiB    1.0%   292KiB
    update nhs                      37   26.3ms    0.1%   710μs   1.93MiB    0.2%  53.5KiB
    compute boundary pressure       74   9.76ms    0.1%   132μs   4.32MiB    0.4%  59.8KiB
    ~update systems and nhs~        37   5.23ms    0.0%   141μs    649KiB    0.1%  17.5KiB
    stress tensor                   37   4.73ms    0.0%   128μs   1.39MiB    0.1%  38.6KiB
    inverse state equation          74   4.07ms    0.0%  55.0μs   0.99MiB    0.1%  13.7KiB
    apply prescribed motion         37   2.10ms    0.0%  56.7μs    870KiB    0.1%  23.5KiB
    update TLSPH positions          37   1.76ms    0.0%  47.6μs    444KiB    0.0%  12.0KiB
    update density diffusion        37   4.42μs    0.0%   119ns     0.00B    0.0%    0.00B
  copy back                         37   1.37ms    0.0%  37.1μs    164KiB    0.0%  4.42KiB
  init                               1   1.08ms    0.0%  1.08ms   1.07MiB    0.1%  1.07MiB
  ~split integration~               38    275μs    0.0%  7.25μs   1.55KiB    0.0%    41.7B
update callback                     38    1.80s   10.2%  47.4ms   16.7MiB    1.6%   450KiB
  ~update callback~                 38    1.75s    9.9%  46.0ms   5.85MiB    0.5%   158KiB
  update systems and nhs            38   55.3ms    0.3%  1.46ms   10.9MiB    1.0%   292KiB
  apply particle shifting           38   3.04μs    0.0%  80.0ns     0.00B    0.0%    0.00B
drift!                             191   58.3ms    0.3%   305μs   45.3MiB    4.2%   243KiB
  velocity                         191   50.0ms    0.3%   262μs   45.0MiB    4.2%   241KiB
  reset ∂u/∂t                      191   7.34ms    0.0%  38.4μs    337KiB    0.0%  1.77KiB
  ~drift!~                         191    948μs    0.0%  4.96μs      976B    0.0%    5.11B
calculate dt                         1   1.73μs    0.0%  1.73μs     0.00B    0.0%    0.00B
──────────────────────────────────────────────────────────────────────────────────────────
```

Most notably, the `update TLSPH positions` is slow in the first simulation because OrdinaryDiffEq does unsynchronized operations on the integration arrays, and the first access to these arrays (which is in update TLSPH positions) implicitly synchronizes, so we are waiting for these OrdinaryDiffEq kernels to finish.
The `ThreadedBroadcastArray` translates all of these operations to `@threaded` loops, which are all synchronized, so the timers now work correctly. One would expect the `% measured` value to drop now because the ODE kernels are now timed outside of any `@trixi_timeit`, but this is not the case, indicating that the ODE stuff actually became significantly faster now for some reason. It is very difficult to find the culplrit for the suboptimal performance in the first simulation because it is not happening in our code and it is not synchronized, so we would have to ask the GPU profiler where this is coming from.