### PR TITLE
Use fast divisions in performance-critical code

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -37,14 +37,17 @@ WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 [weakdeps]
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 
 [extensions]
 TrixiParticlesOrdinaryDiffEqExt = ["OrdinaryDiffEq", "OrdinaryDiffEqCore"]
+TrixiParticlesCUDAExt = "CUDA"
 
 [compat]
 Accessors = "0.1.43"
 Adapt = "4"
 CSV = "0.10"
+CUDA = "5.9.1"
 DataFrames = "1.6"
 DelimitedFiles = "1"
 DiffEqCallbacks = "4"

--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -66,3 +66,39 @@ To create a new release for TrixiParticles.jl, perform the following steps:
    version should be `v0.3.1-dev`. If you just released `v0.2.4`, the new development
    version should be `v0.2.5-dev`.
 
+## Writing GPU-compatible code (@id writing_gpu_code)
+
+When implementing new functionality that should run on both CPUs and GPUs,
+follow these rules:
+
+1. Data structures must be generic and parametric.
+   Do not hardcode concrete CPU array types like `Vector` or `Matrix` in fields.
+   Use type parameters, so the same structure can store CPU arrays and GPU arrays.
+2. Add an Adapt.jl rule in `src/general/gpu.jl`.
+   Register the new type with `Adapt.@adapt_structure ...`, so `adapt` can recursively
+   convert all arrays inside the structure to GPU arrays.
+   This conversion is then applied automatically inside `semidiscretize`.
+3. Use `@threaded` for all loops.
+   Accessing GPU arrays inside regular loops is not allowed.
+   With a GPU backend, `@threaded` loops are compiled to GPU kernels.
+4. Write type-stable code and do not allocate inside `@threaded` loops.
+   This is required for GPU kernels and is also essential for fast multithreaded CPU code.
+
+## Writing fast GPU code
+
+The following rules improve kernel performance and avoid common GPU pitfalls:
+
+1. Avoid exceptions and bounds errors inside kernels.
+   Perform all required checks before entering `@threaded` loops (that is, before GPU kernels).
+   Then use `@inbounds` directly at the loop where bounds are guaranteed.
+   In TrixiParticles.jl, we do not place `@inbounds` inside inner helper functions.
+   Instead, mark helper functions with `@propagate_inbounds` so the loop-level
+   `@inbounds` is propagated.
+2. Avoid implicit `Float64` literals in arithmetic.
+   For example, prefer `x / 2` over `0.5 * x` so `Float32` simulations stay in `Float32`.
+   Verify this with `@device_code`, or by confirming the kernel runs on an Apple GPU
+   (most Apple GPUs do not support `Float64`).
+3. Use `div_fast` only in performance-critical divisions and only after benchmarking.
+   It can significantly speed up kernels, but should not be applied indiscriminately.
+   When introducing `div_fast` in code, add a reference to [this section](@ref gpu_div_fast)
+   to document the rationale and benchmarking context.

--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -98,7 +98,13 @@ The following rules improve kernel performance and avoid common GPU pitfalls:
    For example, prefer `x / 2` over `0.5 * x` so `Float32` simulations stay in `Float32`.
    Verify this with `@device_code`, or by confirming the kernel runs on an Apple GPU
    (most Apple GPUs do not support `Float64`).
-3. Use `div_fast` only in performance-critical divisions and only after benchmarking.
+3. Use `div_fast` in performance-critical divisions, but only after benchmarking (!).
    It can significantly speed up kernels, but should not be applied indiscriminately.
    When introducing `div_fast` in code, add a reference to [this section](@ref writing_fast_gpu_code)
-   to document the rationale and benchmarking context.
+   to document the rationale and benchmarking context, e.g., like so:
+   ```julia
+   # Since this is one of the most performance critical functions, using fast divisions
+   # here gives a significant speedup on GPUs.
+   # See the docs page "Development" for more details on `div_fast`.
+   result = div_fast(divident, divisor)
+   ```

--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -106,5 +106,5 @@ The following rules improve kernel performance and avoid common GPU pitfalls:
    # Since this is one of the most performance critical functions, using fast divisions
    # here gives a significant speedup on GPUs.
    # See the docs page "Development" for more details on `div_fast`.
-   result = div_fast(divident, divisor)
+   result = div_fast(dividend, divisor)
    ```

--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -66,7 +66,7 @@ To create a new release for TrixiParticles.jl, perform the following steps:
    version should be `v0.3.1-dev`. If you just released `v0.2.4`, the new development
    version should be `v0.2.5-dev`.
 
-## Writing GPU-compatible code (@id writing_gpu_code)
+## [Writing GPU-compatible code](@id writing_gpu_code)
 
 When implementing new functionality that should run on both CPUs and GPUs,
 follow these rules:
@@ -84,7 +84,7 @@ follow these rules:
 4. Write type-stable code and do not allocate inside `@threaded` loops.
    This is required for GPU kernels and is also essential for fast multithreaded CPU code.
 
-## Writing fast GPU code
+## [Writing fast GPU code](@id writing_fast_gpu_code)
 
 The following rules improve kernel performance and avoid common GPU pitfalls:
 
@@ -100,5 +100,5 @@ The following rules improve kernel performance and avoid common GPU pitfalls:
    (most Apple GPUs do not support `Float64`).
 3. Use `div_fast` only in performance-critical divisions and only after benchmarking.
    It can significantly speed up kernels, but should not be applied indiscriminately.
-   When introducing `div_fast` in code, add a reference to [this section](@ref gpu_div_fast)
+   When introducing `div_fast` in code, add a reference to [this section](@ref writing_fast_gpu_code)
    to document the rationale and benchmarking context.

--- a/docs/src/gpu.md
+++ b/docs/src/gpu.md
@@ -137,3 +137,8 @@ On GPUs that do not support `Float64`, such as most Apple GPUs, we also need to 
 the coordinates to `Float32` by passing `coordinates_eltype=Float32` to
 the setup functions that create [`InitialCondition`](@ref)s, such as
 [`RectangularTank`](@ref), [`RectangularShape`](@ref), and [`SphereShape`](@ref).
+
+## Writing GPU-compatible code
+
+Please see the [development documentation](@ref writing_gpu_code) for guidelines on
+how to write GPU-compatible code.

--- a/ext/TrixiParticlesCUDAExt.jl
+++ b/ext/TrixiParticlesCUDAExt.jl
@@ -1,3 +1,5 @@
+# TODO this might be integrated into CUDA.jl at some point, see
+# https://github.com/JuliaGPU/CUDA.jl/pull/3077
 module TrixiParticlesCUDAExt
 
 using CUDA: CUDA

--- a/ext/TrixiParticlesCUDAExt.jl
+++ b/ext/TrixiParticlesCUDAExt.jl
@@ -1,0 +1,32 @@
+module TrixiParticlesCUDAExt
+
+using CUDA: CUDA
+using TrixiParticles: TrixiParticles
+
+# Use faster version of `div_fast` for `Float64` on CUDA.
+# By default, `div_fast` translates to `Base.FastMath.div_fast`, but there is
+# no fast division for `Float64` on CUDA, so we need to redefine it here to use the
+# improved fast reciprocal defined below.
+CUDA.@device_override TrixiParticles.div_fast(x, y::Float64) = x * fast_inv_cuda(y)
+
+# Improved fast reciprocal for `Float64` by @Mikolaj-A-Kowalski, which is significantly
+# more accurate than just calling "llvm.nvvm.rcp.approx.ftz.d" without the cubic iteration,
+# while still being much faster than a full division.
+# This is copied from Oceananigans.jl, see https://github.com/CliMA/Oceananigans.jl/pull/5140.
+@inline function fast_inv_cuda(a::Float64)
+    # Get the approximate reciprocal
+    # https://docs.nvidia.com/cuda/parallel-thread-execution/#floating-point-instructions-rcp-approx-ftz-f64
+    # This instruction chops off last 32bits of mantissa and computes inverse
+    # while treating all subnormal numbers as 0.0
+    # If reciprocal would be subnormal, underflows to 0.0
+    # 32 least significant bits of the result are filled with 0s
+    inv_a = ccall("llvm.nvvm.rcp.approx.ftz.d", llvmcall, Float64, (Float64,), a)
+
+    # Approximate the missing 32bits of mantissa with a single cubic iteration
+    e = fma(inv_a, -a, 1.0)
+    e = fma(e, e, e)
+    inv_a = fma(e, inv_a, inv_a)
+    return inv_a
+end
+
+end # module

--- a/src/general/gpu.jl
+++ b/src/general/gpu.jl
@@ -35,4 +35,3 @@ end
 function allocate(backend, ELTYPE, size)
     return Array{ELTYPE, length(size)}(undef, size)
 end
-

--- a/src/general/gpu.jl
+++ b/src/general/gpu.jl
@@ -35,3 +35,4 @@ end
 function allocate(backend, ELTYPE, size)
     return Array{ELTYPE, length(size)}(undef, size)
 end
+

--- a/src/schemes/fluid/fluid.jl
+++ b/src/schemes/fluid/fluid.jl
@@ -150,7 +150,7 @@ end
                                                particle_system, neighbor_system,
                                                particle, neighbor, rho_a, rho_b)
 
-    dv[end, particle] += rho_a / rho_b * m_b * dot(vdiff, grad_kernel)
+    dv[end, particle] += div_fast(rho_a, rho_b) * m_b * dot(vdiff, grad_kernel)
 
     # Artificial density diffusion should only be applied to systems representing a fluid
     # with the same physical properties i.e. density and viscosity.

--- a/src/schemes/fluid/fluid.jl
+++ b/src/schemes/fluid/fluid.jl
@@ -150,6 +150,9 @@ end
                                                particle_system, neighbor_system,
                                                particle, neighbor, rho_a, rho_b)
 
+    # Since this is one of the most performance critical functions, using fast divisions
+    # here gives a significant speedup on GPUs.
+    # See the docs page "Development" for more details on `div_fast`.
     dv[end, particle] += div_fast(rho_a, rho_b) * m_b * dot(vdiff, grad_kernel)
 
     # Artificial density diffusion should only be applied to systems representing a fluid

--- a/src/schemes/fluid/pressure_acceleration.jl
+++ b/src/schemes/fluid/pressure_acceleration.jl
@@ -7,6 +7,9 @@
 # asymmetric version.
 @inline function pressure_acceleration_summation_density(m_a, m_b, rho_a, rho_b, p_a, p_b,
                                                          W_a)
+    # Since this is one of the most performance critical functions, using fast divisions
+    # here gives a significant speedup on GPUs.
+    # See the docs page "Development" for more details on `div_fast`.
     return -m_b * (div_fast(p_a, rho_a^2) + div_fast(p_b, rho_b^2)) * W_a
 end
 
@@ -14,6 +17,9 @@ end
 # corrections that do not produce a symmetric kernel gradient.
 @inline function pressure_acceleration_summation_density(m_a, m_b, rho_a, rho_b, p_a, p_b,
                                                          W_a, W_b)
+    # Since this is one of the most performance critical functions, using fast divisions
+    # here gives a significant speedup on GPUs.
+    # See the docs page "Development" for more details on `div_fast`.
     return -m_b * (div_fast(p_a, rho_a^2) * W_a - div_fast(p_b, rho_b^2) * W_b)
 end
 
@@ -28,6 +34,7 @@ end
                                                           W_a)
     # Since this is one of the most performance critical functions, using fast divisions
     # here gives a significant speedup on GPUs.
+    # See the docs page "Development" for more details on `div_fast`.
     return -m_b * div_fast(p_a + p_b, rho_a * rho_b) * W_a
 end
 
@@ -35,6 +42,9 @@ end
 # corrections that do not produce a symmetric kernel gradient.
 @inline function pressure_acceleration_continuity_density(m_a, m_b, rho_a, rho_b, p_a, p_b,
                                                           W_a, W_b)
+    # Since this is one of the most performance critical functions, using fast divisions
+    # here gives a significant speedup on GPUs.
+    # See the docs page "Development" for more details on `div_fast`.
     return -div_fast(m_b, rho_a * rho_b) * (p_a * W_a - p_b * W_b)
 end
 

--- a/src/schemes/fluid/pressure_acceleration.jl
+++ b/src/schemes/fluid/pressure_acceleration.jl
@@ -7,14 +7,14 @@
 # asymmetric version.
 @inline function pressure_acceleration_summation_density(m_a, m_b, rho_a, rho_b, p_a, p_b,
                                                          W_a)
-    return -m_b * (p_a / rho_a^2 + p_b / rho_b^2) * W_a
+    return -m_b * (div_fast(p_a, rho_a^2) + div_fast(p_b, rho_b^2)) * W_a
 end
 
 # Same as above, but not assuming symmetry of the kernel gradient. To be used with
 # corrections that do not produce a symmetric kernel gradient.
 @inline function pressure_acceleration_summation_density(m_a, m_b, rho_a, rho_b, p_a, p_b,
                                                          W_a, W_b)
-    return -m_b * (p_a / rho_a^2 * W_a - p_b / rho_b^2 * W_b)
+    return -m_b * (div_fast(p_a, rho_a^2) * W_a - div_fast(p_b, rho_b^2) * W_b)
 end
 
 # As shown in "Variational and momentum preservation aspects of Smooth Particle Hydrodynamic
@@ -26,14 +26,16 @@ end
 # asymmetric version.
 @inline function pressure_acceleration_continuity_density(m_a, m_b, rho_a, rho_b, p_a, p_b,
                                                           W_a)
-    return -m_b * (p_a + p_b) / (rho_a * rho_b) * W_a
+    # Since this is one of the most performance critical functions, using fast divisions
+    # here gives a significant speedup on GPUs.
+    return -m_b * div_fast(p_a + p_b, rho_a * rho_b) * W_a
 end
 
 # Same as above, but not assuming symmetry of the kernel gradient. To be used with
 # corrections that do not produce a symmetric kernel gradient.
 @inline function pressure_acceleration_continuity_density(m_a, m_b, rho_a, rho_b, p_a, p_b,
                                                           W_a, W_b)
-    return -m_b / (rho_a * rho_b) * (p_a * W_a - p_b * W_b)
+    return -div_fast(m_b, rho_a * rho_b) * (p_a * W_a - p_b * W_b)
 end
 
 @doc raw"""

--- a/src/schemes/fluid/viscosity.jl
+++ b/src/schemes/fluid/viscosity.jl
@@ -127,8 +127,10 @@ end
     # approaching particles and turn it off for receding particles. In this way, the
     # viscosity is used for shocks and not rarefactions."
     if vr < 0
-        mu = h * vr / (distance^2 + epsilon * h^2)
-        return (alpha * c * mu + beta * mu^2) / rho_mean * grad_kernel
+        # Since this is one of the most performance critical functions, using fast divisions
+        # here gives a significant speedup on GPUs.
+        mu = div_fast(h * vr, distance^2 + epsilon * h^2)
+        return div_fast(alpha * c * mu + beta * mu^2, rho_mean) * grad_kernel
     end
 
     return zero(v_diff)

--- a/src/schemes/fluid/viscosity.jl
+++ b/src/schemes/fluid/viscosity.jl
@@ -129,6 +129,7 @@ end
     if vr < 0
         # Since this is one of the most performance critical functions, using fast divisions
         # here gives a significant speedup on GPUs.
+        # See the docs page "Development" for more details on `div_fast`.
         mu = div_fast(h * vr, distance^2 + epsilon * h^2)
         return div_fast(alpha * c * mu + beta * mu^2, rho_mean) * grad_kernel
     end

--- a/src/schemes/fluid/viscosity.jl
+++ b/src/schemes/fluid/viscosity.jl
@@ -145,8 +145,11 @@ end
     mu_a = nu_a * rho_a
     mu_b = nu_b * rho_b
 
-    return (mu_a + mu_b) / (rho_a * rho_b) * dot(pos_diff, grad_kernel) /
-           (distance^2 + epsilon * h^2) * v_diff
+    # Since this is one of the most performance critical functions, using fast divisions
+    # here gives a significant speedup on GPUs.
+    # See the docs page "Development" for more details on `div_fast`.
+    return div_fast((mu_a + mu_b) * dot(pos_diff, grad_kernel),
+                    rho_a * rho_b * (distance^2 + epsilon * h^2)) * v_diff
 end
 
 # See, e.g.,
@@ -180,17 +183,20 @@ struct ViscosityAdami{ELTYPE}
     end
 end
 
-function adami_viscosity_force(smoothing_length_average, pos_diff, distance, grad_kernel,
+function adami_viscosity_force(h, pos_diff, distance, grad_kernel,
                                m_a, m_b, rho_a, rho_b, v_diff, nu_a, nu_b, epsilon)
     eta_a = nu_a * rho_a
     eta_b = nu_b * rho_b
 
-    eta_tilde = 2 * (eta_a * eta_b) / (eta_a + eta_b)
+    # Since this is one of the most performance critical functions, using fast divisions
+    # here gives a significant speedup on GPUs.
+    # See the docs page "Development" for more details on `div_fast`.
+    volume_a = div_fast(m_a, rho_a)
+    volume_b = div_fast(m_b, rho_b)
 
-    tmp = eta_tilde / (distance^2 + epsilon * smoothing_length_average^2)
-
-    volume_a = m_a / rho_a
-    volume_b = m_b / rho_b
+    # eta_tilde = 2 * (eta_a * eta_b) / (eta_a + eta_b)
+    # tmp = eta_tilde / (distance^2 + epsilon * h^2) / m_a
+    tmp = div_fast(2 * eta_a * eta_b, (eta_a + eta_b) * (distance^2 + epsilon * h^2) * m_a)
 
     # This formulation was introduced by Hu and Adams (2006). https://doi.org/10.1016/j.jcp.2005.09.001
     # They argued that the formulation is more flexible because of the possibility to formulate
@@ -201,9 +207,9 @@ function adami_viscosity_force(smoothing_length_average, pos_diff, distance, gra
     # Because when using this formulation for the pressure acceleration, it is not
     # energy conserving.
     # See issue: https://github.com/trixi-framework/TrixiParticles.jl/issues/394
-    visc = (volume_a^2 + volume_b^2) * dot(grad_kernel, pos_diff) * tmp / m_a
+    visc = (volume_a^2 + volume_b^2) * dot(grad_kernel, pos_diff) * tmp
 
-    return visc .* v_diff
+    return visc * v_diff
 end
 
 @inline function (viscosity::ViscosityAdami)(particle_system, neighbor_system,
@@ -337,7 +343,10 @@ ViscosityAdamiSGS(; nu, C_S=0.1, epsilon=0.001) = ViscosityAdamiSGS(nu, C_S, eps
     # and then the Smagorinsky eddy viscosity:
     #   ν_SGS = (C_S * h̄)^2 * S_mag.
     #
-    S_mag = norm(v_diff) / (distance + epsilon)
+     # Since this is one of the most performance critical functions, using fast divisions
+    # here gives a significant speedup on GPUs.
+    # See the docs page "Development" for more details on `div_fast`.
+    S_mag = div_fast(sqrt(dot(v_diff, v_diff)), (distance + epsilon))
     nu_SGS = (viscosity.C_S * smoothing_length_average)^2 * S_mag
 
     # Effective kinematic viscosity is the sum of the standard and SGS parts.
@@ -415,7 +424,7 @@ ViscosityMorrisSGS(; nu, C_S=0.1, epsilon=0.001) = ViscosityMorrisSGS(nu, C_S, e
 
     smoothing_length_particle = smoothing_length(particle_system, particle)
     smoothing_length_neighbor = smoothing_length(particle_system, neighbor)
-    smoothing_length_average = (smoothing_length_particle + smoothing_length_neighbor) / 2
+    h = (smoothing_length_particle + smoothing_length_neighbor) / 2
 
     nu_a = kinematic_viscosity(particle_system,
                                viscosity_model(neighbor_system, particle_system),
@@ -430,8 +439,11 @@ ViscosityMorrisSGS(; nu, C_S=0.1, epsilon=0.001) = ViscosityMorrisSGS(nu, C_S, e
 
     # SGS part: Compute the subgrid-scale eddy viscosity.
     # See comments above for `ViscosityAdamiSGS`.
-    S_mag = norm(v_diff) / (distance + epsilon)
-    nu_SGS = (viscosity.C_S * smoothing_length_average)^2 * S_mag
+    # Since this is one of the most performance critical functions, using fast divisions
+    # here gives a significant speedup on GPUs.
+    # See the docs page "Development" for more details on `div_fast`.
+    S_mag = div_fast(sqrt(dot(v_diff, v_diff)), (distance + epsilon))
+    nu_SGS = (viscosity.C_S * h)^2 * S_mag
 
     # Effective viscosities include the SGS term.
     nu_a_eff = nu_a + nu_SGS
@@ -441,9 +453,11 @@ ViscosityMorrisSGS(; nu, C_S=0.1, epsilon=0.001) = ViscosityMorrisSGS(nu, C_S, e
     mu_a = nu_a_eff * rho_a
     mu_b = nu_b_eff * rho_b
 
-    force_Morris = (mu_a + mu_b) / (rho_a * rho_b) * (dot(pos_diff, grad_kernel)) /
-                   (distance^2 + epsilon * smoothing_length_average^2) * v_diff
-    return m_b * force_Morris
+    # Since this is one of the most performance critical functions, using fast divisions
+    # here gives a significant speedup on GPUs.
+    # See the docs page "Development" for more details on `div_fast`.
+    return div_fast(m_b * (mu_a + mu_b) * dot(pos_diff, grad_kernel),
+                    rho_a * rho_b * (distance^2 + epsilon * h^2)) * v_diff
 end
 
 function kinematic_viscosity(system, viscosity::ViscosityMorrisSGS, smoothing_length,
@@ -499,7 +513,10 @@ end
     v_b = viscous_velocity(v_neighbor_system, neighbor_system, neighbor)
     v_diff = v_a - v_b
 
-    gamma_dot = norm(v_diff) / (distance + epsilon)
+    # Since this is one of the most performance critical functions, using fast divisions
+    # here gives a significant speedup on GPUs.
+    # See the docs page "Development" for more details on `div_fast`.
+    gamma_dot = div_fast(sqrt(dot(v_diff, v_diff)), (distance + epsilon))
 
     # Compute Carreau-Yasuda effective viscosity
     (; nu0, nu_inf, lambda, a, n) = viscosity

--- a/src/schemes/fluid/viscosity.jl
+++ b/src/schemes/fluid/viscosity.jl
@@ -343,7 +343,7 @@ ViscosityAdamiSGS(; nu, C_S=0.1, epsilon=0.001) = ViscosityAdamiSGS(nu, C_S, eps
     # and then the Smagorinsky eddy viscosity:
     #   ν_SGS = (C_S * h̄)^2 * S_mag.
     #
-     # Since this is one of the most performance critical functions, using fast divisions
+    # Since this is one of the most performance critical functions, using fast divisions
     # here gives a significant speedup on GPUs.
     # See the docs page "Development" for more details on `div_fast`.
     S_mag = div_fast(sqrt(dot(v_diff, v_diff)), (distance + epsilon))

--- a/src/schemes/fluid/weakly_compressible_sph/density_diffusion.jl
+++ b/src/schemes/fluid/weakly_compressible_sph/density_diffusion.jl
@@ -154,8 +154,8 @@ function allocate_buffer(ic, dd::DensityDiffusionAntuono, buffer::SystemBuffer)
 end
 
 @propagate_inbounds function density_diffusion_psi(density_diffusion::DensityDiffusionAntuono,
-                                       rho_a, rho_b, pos_diff, distance, system,
-                                       particle, neighbor)
+                                                   rho_a, rho_b, pos_diff, distance, system,
+                                                   particle, neighbor)
     (; normalized_density_gradient) = density_diffusion
 
     # Fist term by Molteni & Colagrossi

--- a/src/schemes/fluid/weakly_compressible_sph/density_diffusion.jl
+++ b/src/schemes/fluid/weakly_compressible_sph/density_diffusion.jl
@@ -48,7 +48,7 @@ end
 
 @inline function density_diffusion_psi(::DensityDiffusionMolteniColagrossi, rho_a, rho_b,
                                        pos_diff, distance, system, particle, neighbor)
-    return 2 * (rho_a - rho_b) * pos_diff / distance^2
+    return div_fast(2 * (rho_a - rho_b), distance^2) * pos_diff
 end
 
 @doc raw"""
@@ -77,9 +77,8 @@ end
 
 @inline function density_diffusion_psi(::DensityDiffusionFerrari, rho_a, rho_b,
                                        pos_diff, distance, system, particle, neighbor)
-    return ((rho_a - rho_b) /
-            (smoothing_length(system, particle) + smoothing_length(system, neighbor))) *
-           pos_diff / distance
+    h = smoothing_length(system, particle) + smoothing_length(system, neighbor)
+    return div_fast((rho_a - rho_b), h * distance) * pos_diff
 end
 
 @doc raw"""
@@ -154,21 +153,20 @@ function allocate_buffer(ic, dd::DensityDiffusionAntuono, buffer::SystemBuffer)
     return initial_condition, DensityDiffusionAntuono(initial_condition; delta=dd.delta)
 end
 
-@inline function density_diffusion_psi(density_diffusion::DensityDiffusionAntuono,
+@propagate_inbounds function density_diffusion_psi(density_diffusion::DensityDiffusionAntuono,
                                        rho_a, rho_b, pos_diff, distance, system,
                                        particle, neighbor)
     (; normalized_density_gradient) = density_diffusion
-
-    normalized_gradient_a = extract_svector(normalized_density_gradient, system, particle)
-    normalized_gradient_b = extract_svector(normalized_density_gradient, system, neighbor)
 
     # Fist term by Molteni & Colagrossi
     result = 2 * (rho_a - rho_b)
 
     # Second correction term
+    normalized_gradient_a = extract_svector(normalized_density_gradient, system, particle)
+    normalized_gradient_b = extract_svector(normalized_density_gradient, system, neighbor)
     result -= dot(normalized_gradient_a + normalized_gradient_b, pos_diff)
 
-    return result * pos_diff / distance^2
+    return div_fast(result, distance^2) * pos_diff
 end
 
 function update!(density_diffusion::DensityDiffusionAntuono, v, u, system, semi)
@@ -217,19 +215,17 @@ end
     # See `src/general/smoothing_kernels.jl` for more details.
     distance^2 < eps(initial_smoothing_length(particle_system)^2) && return
 
-    (; delta) = density_diffusion
-    sound_speed = system_sound_speed(particle_system)
-
-    volume_b = m_b / rho_b
-
+    volume_b = div_fast(m_b, rho_b)
     psi = density_diffusion_psi(density_diffusion, rho_a, rho_b, pos_diff, distance,
                                 particle_system, particle, neighbor)
-    density_diffusion_term = dot(psi, grad_kernel) * volume_b
+    density_diffusion_term = volume_b * dot(psi, grad_kernel)
 
     smoothing_length_avg = (smoothing_length(particle_system, particle) +
                             smoothing_length(particle_system, neighbor)) / 2
-    dv[end, particle] += delta * smoothing_length_avg * sound_speed *
-                         density_diffusion_term
+
+    (; delta) = density_diffusion
+    sound_speed = system_sound_speed(particle_system)
+    dv[end, particle] += delta * smoothing_length_avg * sound_speed * density_diffusion_term
 end
 
 # Density diffusion `nothing` or interaction other than fluid-fluid

--- a/src/schemes/fluid/weakly_compressible_sph/density_diffusion.jl
+++ b/src/schemes/fluid/weakly_compressible_sph/density_diffusion.jl
@@ -164,7 +164,7 @@ end
                                                    particle, neighbor)
     (; normalized_density_gradient) = density_diffusion
 
-    # Fist term by Molteni & Colagrossi
+    # First term by Molteni & Colagrossi
     result = 2 * (rho_a - rho_b)
 
     # Second correction term

--- a/src/schemes/fluid/weakly_compressible_sph/density_diffusion.jl
+++ b/src/schemes/fluid/weakly_compressible_sph/density_diffusion.jl
@@ -48,6 +48,9 @@ end
 
 @inline function density_diffusion_psi(::DensityDiffusionMolteniColagrossi, rho_a, rho_b,
                                        pos_diff, distance, system, particle, neighbor)
+    # Since this is one of the most performance critical functions, using fast divisions
+    # here gives a significant speedup on GPUs.
+    # See the docs page "Development" for more details on `div_fast`.
     return div_fast(2 * (rho_a - rho_b), distance^2) * pos_diff
 end
 
@@ -77,6 +80,9 @@ end
 
 @inline function density_diffusion_psi(::DensityDiffusionFerrari, rho_a, rho_b,
                                        pos_diff, distance, system, particle, neighbor)
+    # Since this is one of the most performance critical functions, using fast divisions
+    # here gives a significant speedup on GPUs.
+    # See the docs page "Development" for more details on `div_fast`.
     h = smoothing_length(system, particle) + smoothing_length(system, neighbor)
     return div_fast((rho_a - rho_b), h * distance) * pos_diff
 end
@@ -166,6 +172,9 @@ end
     normalized_gradient_b = extract_svector(normalized_density_gradient, system, neighbor)
     result -= dot(normalized_gradient_a + normalized_gradient_b, pos_diff)
 
+    # Since this is one of the most performance critical functions, using fast divisions
+    # here gives a significant speedup on GPUs.
+    # See the docs page "Development" for more details on `div_fast`.
     return div_fast(result, distance^2) * pos_diff
 end
 
@@ -215,6 +224,9 @@ end
     # See `src/general/smoothing_kernels.jl` for more details.
     distance^2 < eps(initial_smoothing_length(particle_system)^2) && return
 
+    # Since this is one of the most performance critical functions, using fast divisions
+    # here gives a significant speedup on GPUs.
+    # See the docs page "Development" for more details on `div_fast`.
     volume_b = div_fast(m_b, rho_b)
     psi = density_diffusion_psi(density_diffusion, rho_a, rho_b, pos_diff, distance,
                                 particle_system, particle, neighbor)

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,3 +1,9 @@
+# By default, use `div_fast` of `Base.FastMath`.
+# In the `TrixiParticlesCUDAExt` extension, this is redefined for `Float64`.
+@inline function div_fast(x, y)
+    return Base.FastMath.div_fast(x, y)
+end
+
 # Same as `foreach`, but it is unrolled by the compiler for small input tuples
 @inline function foreach_noalloc(func, collection)
     element = first(collection)

--- a/test/examples/gpu.jl
+++ b/test/examples/gpu.jl
@@ -5,11 +5,13 @@ if TRIXIPARTICLES_TEST_ == "cuda"
     CUDA.versioninfo()
     parallelization_backend = CUDABackend()
     supports_double_precision = true
+    fp64_fastdiv = true
 elseif TRIXIPARTICLES_TEST_ == "amdgpu"
     using AMDGPU
     AMDGPU.versioninfo()
     parallelization_backend = ROCBackend()
     supports_double_precision = true
+    fp64_fastdiv = false
 elseif TRIXIPARTICLES_TEST_ == "metal"
     using Metal
     Metal.versioninfo()
@@ -23,6 +25,46 @@ elseif TRIXIPARTICLES_TEST_ == "oneapi"
     supports_double_precision = false
 else
     error("Unknown GPU backend: $TRIXIPARTICLES_TEST_")
+end
+
+@testset verbose=true "div_fast $TRIXIPARTICLES_TEST_" begin
+    @testset verbose=true "CPU $T" for T in [Float32, Float64]
+        x = T(pi)
+        y = rand(T, 1024) .+ 1
+
+        # `div_fast` is a regular division on the CPU, so we expect exact equality
+        @test TrixiParticles.div_fast.(x, y) == x ./ y
+    end
+
+    @testset verbose=true "GPU Float32" begin
+        x = Float32(pi)
+        y = Adapt.adapt(parallelization_backend, rand(Float32, 1024) .+ 1)
+
+        max_error = maximum(abs.(TrixiParticles.div_fast.(x, y) - x ./ y))
+        @test max_error < 1f-6
+
+        # Make sure that this is actually using a fast division
+        @test max_error > 0
+    end
+
+    if supports_double_precision
+        @testset verbose=true "GPU Float64" begin
+            x = Float64(pi)
+            y = Adapt.adapt(parallelization_backend, rand(Float64, 1024) .+ 1)
+
+            max_error = maximum(abs.(TrixiParticles.div_fast.(x, y) - x ./ y))
+
+            if fp64_fastdiv
+                @test max_error < 1e-15
+
+                # Make sure that this is actually using a fast division
+                @test max_error > 0
+            else
+                # If fast division for Float64 is not supported, we expect exact equality
+                @test max_error == 0
+            end
+        end
+    end
 end
 
 @testset verbose=true "Examples $TRIXIPARTICLES_TEST_" begin

--- a/test/examples/gpu.jl
+++ b/test/examples/gpu.jl
@@ -43,7 +43,7 @@ end
         # We don't test `max_error > 0`, since this might be exact on some CPUs
         # (we observed this on ARM CPUs).
         max_error = maximum(abs.(TrixiParticles.div_fast.(x, y) - x ./ y))
-        @test max_error < 1f-6
+        @test max_error < 1.0f-6
     end
 
     @testset verbose=true "GPU Float32" begin

--- a/test/examples/gpu.jl
+++ b/test/examples/gpu.jl
@@ -28,12 +28,22 @@ else
 end
 
 @testset verbose=true "div_fast $TRIXIPARTICLES_TEST_" begin
-    @testset verbose=true "CPU $T" for T in [Float32, Float64]
-        x = T(pi)
-        y = rand(T, 1024) .+ 1
+    @testset verbose=true "CPU Float64" begin
+        x = Float64(pi)
+        y = rand(Float64, 1024) .+ 1
 
-        # `div_fast` is a regular division on the CPU, so we expect exact equality
+        # We expect exact equality for `Float64` on the CPU
         @test TrixiParticles.div_fast.(x, y) == x ./ y
+    end
+
+    @testset verbose=true "CPU Float32" begin
+        x = Float32(pi)
+        y = rand(Float32, 1024) .+ 1
+
+        # We don't test `max_error > 0`, since this might be exact on some CPUs
+        # (we observed this on ARM CPUs).
+        max_error = maximum(abs.(TrixiParticles.div_fast.(x, y) - x ./ y))
+        @test max_error < 1f-6
     end
 
     @testset verbose=true "GPU Float32" begin

--- a/test/examples/gpu.jl
+++ b/test/examples/gpu.jl
@@ -41,7 +41,7 @@ end
         y = Adapt.adapt(parallelization_backend, rand(Float32, 1024) .+ 1)
 
         max_error = maximum(abs.(TrixiParticles.div_fast.(x, y) - x ./ y))
-        @test max_error < 1f-6
+        @test max_error < 1.0f-6
 
         # Make sure that this is actually using a fast division
         @test max_error > 0

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -2,6 +2,7 @@ using Test
 using TrixiTest: @trixi_test_nowarn
 using TrixiParticles
 using TrixiParticles: PointNeighbors
+using TrixiParticles.Adapt
 using LinearAlgebra
 using Printf
 using CSV: CSV


### PR DESCRIPTION
This PR switches all divisions inside the neighbor loop to fast divisions. The fluid-* interaction kernel now still contains regular divisions in the PointNeighbors.jl part, but not for each neighbor particle, so these don't make a noticeable difference.

As shown in the benchmarks in #1116, these fast divisions make a massive difference in the runtime of the fluid-* interaction kernel, but they don't work with `Float64`. @Mikolaj-A-Kowalski wrote this incredible `fast_inv_cuda` function to get fast divisions with `Float64` without losing much accuracy in https://github.com/CliMA/Oceananigans.jl/pull/5140.

Here is a simple demonstration of the accuracy of this function vs a simple `llvm.nvvm.rcp.approx.ftz.d` without the following iteration:
```julia
julia> y2 = CUDA.rand(Float64, 100_000) .+ 0.1; # avoid numbers close to zero

julia> maximum(inv.(y2) .- fast_inv_cuda_nofma.(y2))
7.105216770497691e-6

julia> maximum(inv.(y2) .- fast_inv_cuda.(y2))
8.881784197001252e-16
```

Here is a comparison of different definitions for `div_fast` with the generated LLVM and corresponding runtime of the fluid-* interact kernel on an H100.
| Variant                        | LLVM Operation (FP32)                                 | Runtime (FP32) | LLVM Operation (FP64)                                 | Runtime (FP64) |
|---------------------------------|------------------------------------------------------|----------------|------------------------------------------------------|----------------|
| `x / y`                        | `fdiv float %143, %144, !dbg !528`                   | 4.894 ms       | `fdiv double %143, %144, !dbg !528`                  | 10.159 ms      |
| `x * (1 / y)`                  | `fdiv float 1.000000e+00, %145, !dbg !530`<br>`fmul float %144, %146, !dbg !533` | 4.227 ms       | `fdiv double 1.000000e+00, %145, !dbg !530`<br>`fmul double %144, %146, !dbg !533` | 6.878 ms       |
| `x * inv(y)`                   | `call float @llvm.nvvm.rcp.rn.f(float %118), !dbg !413`<br>`fmul float %117, %119, !dbg !418` | 3.620 ms       | `fdiv double 1.000000e+00, %145, !dbg !532`<br>`fmul double %144, %146, !dbg !535` | 6.852 ms       |
| `x * fast_inv_cuda(y)`         | `call float @llvm.nvvm.rcp.approx.ftz.f(float %118), !dbg !413`<br>`fmul float %117, %119, !dbg !418` | 3.281 ms       | `call double @llvm.nvvm.rcp.approx.ftz.d(double %118), !dbg !413`<br>`fneg double %118, !dbg !418`<br>`call double @llvm.fma.f64(double %119, double %120, double 1.000000e+00), !dbg !420`<br>`call double @llvm.fma.f64(double %121, double %121, double %121), !dbg !422`<br>`call double @llvm.fma.f64(double %122, double %119, double %119), !dbg !424`<br>`fmul double %117, %123, !dbg !426` | 4.844 ms       |
| `Base.FastMath.div_fast(x, y)` | `call float @llvm.nvvm.div.approx.f(float %118, float %115), !dbg !413` | 3.114 ms       | `fdiv fast double %143, %144, !dbg !530`             | 10.114 ms      |
| `x * fast_inv_cuda_nofma(y)`   | `call double @llvm.nvvm.rcp.approx.ftz.d(double %118), !dbg !413`<br>`fmul double %117, %119, !dbg !418` | —              | —                                                    | 4.758 ms       |

With `Float32`, `1 / y` is faster than `x / y`, but it doesn't produce a reciprocal instruction.
`inv` does produce a reciprocal and is faster. The approx reciprocal is even faster, but still not as fast as the fast division.
With `Float64`, `x / y` is translated to a `fdiv fast`, but (as expected, since there is no double fast division in PTX), this is not faster. `1 / y` and `inv` are both translated to `fdiv double 1.0 ...` and are significantly faster than the regular division. `fast_inv_cuda` is even faster, and skipping the Newton-iteration makes it only 1.018x faster (at a significant loss of accuracy).