### PR TITLE
Fix deformation gradient performance in 3D

### DIFF
--- a/src/schemes/structure/total_lagrangian_sph/system.jl
+++ b/src/schemes/structure/total_lagrangian_sph/system.jl
@@ -539,8 +539,10 @@ end
             pos_diff = convert.(eltype(system), pos_diff_)
 
             # The tensor product pos_diff ⊗ (L_{0a} * ∇W) is equivalent to multiplication
-            # by the transpose: pos_diff * (L_{0a} * ∇W)ᵀ = pos_diff * ∇Wᵀ * L_{0a}ᵀ.
-            result[] -= volume * pos_diff * grad_kernel' * L_a'
+            # by the transpose: pos_diff * (L_{0a} * ∇W)ᵀ = (L_{0a} * ∇W * pos_diffᵀ)ᵀ
+            # This is a lot faster than `pos_diff * grad_kernel' * L_a'` in 3D.
+            F_T = -volume * L_a * grad_kernel * pos_diff'
+            result[] += F_T'
         end
 
         for j in 1:ndims(system), i in 1:ndims(system)

--- a/src/schemes/structure/total_lagrangian_sph/system.jl
+++ b/src/schemes/structure/total_lagrangian_sph/system.jl
@@ -540,7 +540,9 @@ end
 
             # The tensor product pos_diff ⊗ (L_{0a} * ∇W) is equivalent to multiplication
             # by the transpose: pos_diff * (L_{0a} * ∇W)ᵀ = (L_{0a} * ∇W * pos_diffᵀ)ᵀ
-            # This is a lot faster than `pos_diff * grad_kernel' * L_a'` in 3D.
+            # The original form is:
+            #   -volume * pos_diff * (L_a * grad_kernel)'
+            # Equivalent transposed form that is much faster in 3D:
             F_T = -volume * L_a * grad_kernel * pos_diff'
             result[] += F_T'
         end


### PR DESCRIPTION
@svchb and @copilot This should be mathematically identical, but please check carefully that this is indeed identical and I did not introduce an error here.

### 3D

| Machine | main | This PR |
|---|---:|---:|
| A4500 | 26.396 ms | 3.457 ms (7.64x) |
| Intel Xeon w9-3475X (x36) | 67.368 ms | 39.861 ms (1.69x) |
| H100 FP64 | 5.774 ms | 1.358 ms (4.25x) |
| H100 FP32 | 3.030 ms | 855.816 μs (3.54x) |

### 2D

| Machine | main | This PR |
|---|---:|---:|
| A4500 | 402.072 μs | 395.481 μs (1.02x) |
| Intel Xeon w9-3475X (x36) | 4.900 ms | 4.855 ms (1.01x) |
| H100 FP64 | 261.475 μs | 256.930 μs (1.02x) |
| H100 FP32 | 157.665 μs | 155.842 μs (1.01x) |