### PR TITLE
Add parallel intitialization for TLSPH arrays to ensure NUMA awareness

### DIFF
--- a/src/general/neighborhood_search.jl
+++ b/src/general/neighborhood_search.jl
@@ -436,6 +436,14 @@ end
 
 # === Initialization ===
 
+# This function is only used below in the NHS initialization.
+@inline initial_coordinates_nhs(system) = initial_coordinates(system)
+
+# TLSPH runtime arrays are initialized after the neighborhood searches for NUMA awareness.
+@inline function initial_coordinates_nhs(system::TotalLagrangianSPHSystem)
+    return system.initial_condition.coordinates
+end
+
 function initialize_neighborhood_searches!(semi, u0_ode, restart_with::Nothing)
     initialize_neighborhood_searches!(semi)
 end
@@ -455,8 +463,8 @@ function initialize_neighborhood_search!(semi, system, neighbor)
     # Currently, this cannot use `semi.parallelization_backend`
     # because data is still on the CPU.
     PointNeighbors.initialize!(get_neighborhood_search(system, neighbor, semi),
-                               initial_coordinates(system),
-                               initial_coordinates(neighbor),
+                               initial_coordinates_nhs(system),
+                               initial_coordinates_nhs(neighbor),
                                eachindex_y=each_active_particle(neighbor),
                                parallelization_backend=PolyesterBackend())
 

--- a/src/schemes/structure/total_lagrangian_sph/system.jl
+++ b/src/schemes/structure/total_lagrangian_sph/system.jl
@@ -145,10 +145,10 @@ function TotalLagrangianSPHSystem(initial_condition; smoothing_kernel, smoothing
         poisson_ratio_sorted = poisson_ratio
     end
 
-    initial_coordinates = copy(initial_condition_sorted.coordinates)
-    current_coordinates = copy(initial_condition_sorted.coordinates)
-    mass = copy(initial_condition_sorted.mass)
-    material_density = copy(initial_condition_sorted.density)
+    initial_coordinates = similar(initial_condition_sorted.coordinates)
+    current_coordinates = similar(initial_condition_sorted.coordinates)
+    mass = similar(initial_condition_sorted.mass)
+    material_density = similar(initial_condition_sorted.density)
     correction_matrix = Array{ELTYPE, 3}(undef, NDIMS, NDIMS, n_particles)
     pk1_rho2 = Array{ELTYPE, 3}(undef, NDIMS, NDIMS, n_particles)
     deformation_grad = Array{ELTYPE, 3}(undef, NDIMS, NDIMS, n_particles)
@@ -392,6 +392,11 @@ function initialize!(system::TotalLagrangianSPHSystem, semi)
     (; correction_matrix) = system
 
     initial_coords = initial_coordinates(system)
+
+    copyto_threaded!(initial_coords, system.initial_condition.coordinates, semi)
+    copyto_threaded!(system.current_coordinates, system.initial_condition.coordinates, semi)
+    copyto_threaded!(system.mass, system.initial_condition.mass, semi)
+    copyto_threaded!(system.material_density, system.initial_condition.density, semi)
 
     density_fun(particle) = system.material_density[particle]
 

--- a/src/schemes/structure/total_lagrangian_sph/system.jl
+++ b/src/schemes/structure/total_lagrangian_sph/system.jl
@@ -209,9 +209,14 @@ function initialize_self_interaction_nhs(system::TotalLagrangianSPHSystem,
     self_interaction_nhs = copy_neighborhood_search(template, search_radius,
                                                     nparticles(system))
 
+    # The runtime arrays of a TLSPH system are intentionally left uninitialized until
+    # `semidiscretize`, where they can be initialized in parallel for NUMA awareness.
+    # Build the static self-interaction NHS directly from the initial condition instead.
+    initial_coordinates = system.initial_condition.coordinates
+
     # Note that for large numbers of particles, initialization can take a while
     PointNeighbors.initialize!(self_interaction_nhs,
-                               system.initial_coordinates, system.initial_coordinates,
+                               initial_coordinates, initial_coordinates,
                                parallelization_backend=PolyesterBackend())
 
     # Self-interaction only requires neighbors in the initial configuration,

--- a/src/util.jl
+++ b/src/util.jl
@@ -301,3 +301,32 @@ function Base.similar(::Broadcast.Broadcasted{ThreadedBroadcastStyle{P}},
     # TODO we only have the type `P` here and just assume that we can do `P()`
     return ThreadedBroadcastArray(similar(Array{T}, dims), parallelization_backend=P())
 end
+
+# Like `copyto!`, but applies the same multithreading strategy as used in TrixiParticles.jl.
+# When combined with `undef` initialization (or `similar`), the first-touch policy
+# assigns memory to the NUMA node local to the thread that the particle is processed on.
+# This initialization approach maximizes memory locality and bandwidth for the subsequent
+# right-hand side evaluation, and therefore improves performance for large problems
+# on large data center CPUs (see http://github.com/trixi-framework/TrixiParticles.jl/pull/1256).
+@inline function copyto_threaded!(dest::Matrix, src, semi)
+    @threaded semi for particle in axes(dest, 2)
+        for i in axes(dest, 1)
+            @inbounds dest[i, particle] = src[i, particle]
+        end
+    end
+
+    return dest
+end
+
+@inline function copyto_threaded!(dest::Vector, src, semi)
+    @threaded semi for particle in eachindex(dest)
+        @inbounds dest[particle] = src[particle]
+    end
+
+    return dest
+end
+
+# On GPUs, using specialized copy kernels is faster than writing our own custom kernel.
+@inline function copyto_threaded!(dest::AbstractGPUArray, src, semi)
+    dest .= src
+end

--- a/test/schemes/boundary/dummy_particles/rhs.jl
+++ b/test/schemes/boundary/dummy_particles/rhs.jl
@@ -82,6 +82,13 @@
                                                         poisson_ratio=0.0,
                                                         boundary_model=boundary_model_continuity)
 
+            # Runtime arrays are initialized in `semidiscretize`, which this low-level
+            # interaction test intentionally skips.
+            structure_system.initial_coordinates .= initial_condition.coordinates
+            structure_system.current_coordinates .= initial_condition.coordinates
+            structure_system.mass .= initial_condition.mass
+            structure_system.material_density .= initial_condition.density
+
             # Positions of the structure particles are not used here
             u_structure = zeros(0, TrixiParticles.nparticles(structure_system))
             v_structure = vcat(initial_condition.velocity,

--- a/test/systems/tlsph_system.jl
+++ b/test/systems/tlsph_system.jl
@@ -30,10 +30,10 @@
             @test system isa TotalLagrangianSPHSystem
             @test ndims(system) == NDIMS
             @test system.initial_condition == initial_condition
-            @test system.initial_coordinates == coordinates
-            @test system.current_coordinates == coordinates
-            @test system.mass == mass
-            @test system.material_density == material_densities
+            @test size(system.initial_coordinates) == size(coordinates)
+            @test size(system.current_coordinates) == size(coordinates)
+            @test size(system.mass) == size(mass)
+            @test size(system.material_density) == size(material_densities)
             @test system.n_integrated_particles == 2
             @test system.young_modulus == E
             @test system.poisson_ratio == nu
@@ -372,6 +372,10 @@
         system = TotalLagrangianSPHSystem(initial_condition; smoothing_kernel,
                                           smoothing_length, young_modulus=E,
                                           poisson_ratio=nu)
+
+        # Runtime arrays are initialized in `semidiscretize`. This test initializes the
+        # other required state manually, so we also initialize the material density.
+        system.material_density .= material_densities
 
         # Initialize deformation_grad and pk1_rho2 with arbitrary values
         for particle in TrixiParticles.eachparticle(system)


### PR DESCRIPTION
Benchmark on 2 x AMD EPYC 9965 (192 cores each) with 8 NUMA domains (48 cores each):
<img width="1874" height="938" alt="grafik" src="https://github.com/user-attachments/assets/853a54c3-1d60-4936-9039-c53b32ff302b" />
We can nicely see how this massive CPU is slow for small problems (when using all 384 cores), reaches maximum performance around 250k particles, then drops again when the problem size exceeds the cache, and then stagnates limited by the memory bandwidth.

The effect is much more pronounced for the deformation gradient:
<img width="1872" height="936" alt="grafik" src="https://github.com/user-attachments/assets/6d8682e6-5d4e-4c3e-9190-2c8e0fa8ca2d" />

With serial initialization, all data lives on one NUMA domain, decreasing memory locality and bandwidth. With parallel initialization, data lives on the NUMA domain belonging to the core that handles the corresponding particle.