### PR TITLE
Add Makie particle visualization

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,13 @@ TrixiParticles.jl follows the interpretation of
 [semantic versioning (semver)](https://julialang.github.io/Pkg.jl/dev/compatibility/#Version-specifier-format-1)
 used in the Julia ecosystem. Notable changes will be documented in this file for human readability.
 
+## Version 0.5.4
+
+### Features
+
+- Added an optional Makie recipe for rendering two- and three-dimensional particle systems
+  with `plot`, `plot!`, `trixi2makie`, and `trixi2makie!`.
+
 ## Version 0.5.3
 
 ### Features
@@ -17,9 +24,6 @@ used in the Julia ecosystem. Notable changes will be documented in this file for
   useful for monitoring progress in real-time on clusters or batch systems (#1246).
 - Added the number of split integration time steps to the `InfoCallback` output
   when a `SplitIntegrationCallback` is used (#1194).
-- Added the optional `trixi2makie` visualization extension for rendering two- and
-  three-dimensional particle systems with Makie.
-
 ### Important Bugfixes
 
 - Fixed signed-distance constraints in `ParticlePackingSystem` when using a separate

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@ used in the Julia ecosystem. Notable changes will be documented in this file for
   useful for monitoring progress in real-time on clusters or batch systems (#1246).
 - Added the number of split integration time steps to the `InfoCallback` output
   when a `SplitIntegrationCallback` is used (#1194).
+
 ### Important Bugfixes
 
 - Fixed signed-distance constraints in `ParticlePackingSystem` when using a separate

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@ used in the Julia ecosystem. Notable changes will be documented in this file for
   useful for monitoring progress in real-time on clusters or batch systems (#1246).
 - Added the number of split integration time steps to the `InfoCallback` output
   when a `SplitIntegrationCallback` is used (#1194).
+- Added the optional `trixi2makie` visualization extension for rendering two- and
+  three-dimensional particle systems with Makie.
 
 ### Important Bugfixes
 

--- a/Project.toml
+++ b/Project.toml
@@ -35,6 +35,7 @@ WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [weakdeps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
 OrdinaryDiffEqLowStorageRK = "b0944070-b475-4768-8dec-fb6eb410534d"
 OrdinaryDiffEqSymplecticRK = "fa646aed-7ef9-47eb-84c4-9443fc8cbfa8"
@@ -43,6 +44,7 @@ Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 [extensions]
 TrixiParticlesOrdinaryDiffEqSymplecticRKExt = ["OrdinaryDiffEqSymplecticRK", "OrdinaryDiffEqCore"]
 TrixiParticlesCUDAExt = "CUDA"
+TrixiParticlesMakieExt = "Makie"
 
 [compat]
 Accessors = "0.1.43"
@@ -60,6 +62,7 @@ GPUArraysCore = "0.2"
 JSON = "1"
 KernelAbstractions = "0.9"
 LinearAlgebra = "1"
+Makie = "0.24"
 OrdinaryDiffEqLowStorageRK = "3"
 OrdinaryDiffEqCore = "4"
 OrdinaryDiffEqSymplecticRK = "2"

--- a/docs/src/visualization.md
+++ b/docs/src/visualization.md
@@ -16,16 +16,16 @@ it does not reconstruct a continuous fluid surface.
 ```julia
 using CairoMakie
 
-figure = Figure()
-axis = LScene(figure[1, 1]; show_axis=false)
-trixi2makie(axis, sol)
-figure
+figure, axis, plot_object = plot(sol)
 ```
 
-Use `frame` to select another saved ODE frame. The keywords `system_indices`, `system_colors`,
-and `marker_size_scales` select and style systems. Colors and size scales can be scalars,
-vectors indexed by system number, or functions with the signature `(system, system_index)`.
-Additional keywords are forwarded to `Makie.meshscatter!`.
+This uses the TrixiParticles Makie recipe. `trixi2makie(sol)` is an equivalent explicit entry
+point, and `plot!(axis, sol)` or `trixi2makie!(axis, sol)` add the visualization to an existing
+axis. Use `frame` to select another saved ODE frame. The keywords `system_indices`,
+`system_colors`, and `marker_size_scales` select and style systems. Colors and size scales can
+be scalars, vectors indexed by system number, or functions with the signature
+`(system, system_index)`. Additional Makie plot attributes are forwarded to the particle
+markers.
 
 ```@docs
 trixi2makie

--- a/docs/src/visualization.md
+++ b/docs/src/visualization.md
@@ -7,6 +7,30 @@ directory relative to the current working directory.
 VTK files can be opened in visualization tools such as [ParaView](https://www.paraview.org/)
 and [VisIt](https://visit.llnl.gov/).
 
+## Makie
+
+Load a Makie backend to inspect any two- or three-dimensional solution frame directly. This
+particle-level diagnostic renders spheres whose diameter follows the system's particle spacing;
+it does not reconstruct a continuous fluid surface.
+
+```julia
+using CairoMakie
+
+figure = Figure()
+axis = LScene(figure[1, 1]; show_axis=false)
+trixi2makie(axis, sol)
+figure
+```
+
+Use `frame` to select another saved ODE frame. The keywords `system_indices`, `system_colors`,
+and `marker_size_scales` select and style systems. Colors and size scales can be scalars,
+vectors indexed by system number, or functions with the signature `(system, system_index)`.
+Additional keywords are forwarded to `Makie.meshscatter!`.
+
+```@docs
+trixi2makie
+```
+
 ### ParaView
 
 Follow these steps to view the exported VTK files in ParaView:

--- a/ext/TrixiParticlesMakieExt.jl
+++ b/ext/TrixiParticlesMakieExt.jl
@@ -1,0 +1,90 @@
+module TrixiParticlesMakieExt
+
+using Makie
+using TrixiParticles
+
+const TP = TrixiParticles
+
+function default_system_color(system, system_index)
+    if system isa TP.AbstractFluidSystem
+        return Makie.RGBf(0.02, 0.32, 0.85)
+    elseif system isa TP.AbstractBoundarySystem
+        return Makie.RGBf(0.62, 0.66, 0.72)
+    elseif system isa TP.AbstractStructureSystem
+        return Makie.RGBf(0.95, 0.48, 0.08)
+    elseif system isa TP.OpenBoundarySystem
+        return Makie.RGBf(0.30, 0.58, 0.82)
+    end
+
+    return Makie.wong_colors()[mod1(system_index, length(Makie.wong_colors()))]
+end
+
+function default_marker_size_scale(system, system_index)
+    if system isa TP.AbstractBoundarySystem || system isa TP.OpenBoundarySystem
+        return 0.55
+    end
+
+    return 0.9
+end
+
+@inline function style_value(style::Function, system, system_index)
+    return style(system, system_index)
+end
+
+@inline function style_value(style::AbstractVector, system, system_index)
+    return style[system_index]
+end
+
+@inline style_value(style, system, system_index) = style
+
+function TP.trixi2makie(scene, solution::TP.TrixiParticlesODESolution;
+                        frame=lastindex(solution.u), kwargs...)
+    v_ode, u_ode = solution.u[frame].x
+    semi = solution.prob.p.semi
+
+    return TP.trixi2makie(scene, v_ode, u_ode, semi; kwargs...)
+end
+
+function TP.trixi2makie(scene, v_ode::AbstractArray, u_ode::AbstractArray,
+                        semi::TP.Semidiscretization;
+                        system_indices=eachindex(semi.systems),
+                        system_colors=default_system_color,
+                        marker_size_scales=default_marker_size_scale,
+                        kwargs...)
+    plots = Any[]
+    marker = Makie.Sphere(Makie.Point3f(0), 0.5f0)
+    for system_index in system_indices
+        system = semi.systems[system_index]
+        particles = TP.eachparticle(system)
+        isempty(particles) && continue
+
+        u = TP.wrap_u(u_ode, system, semi)
+        coordinates = Array(TP.active_coordinates(u, system))
+        points = makie_points(coordinates)
+        spacing = TP.particle_spacing(system, first(particles))
+        color = style_value(system_colors, system, system_index)
+        marker_size_scale = style_value(marker_size_scales, system, system_index)
+
+        plot = Makie.meshscatter!(scene, points; marker,
+                                  markersize=marker_size_scale * spacing,
+                                  color, kwargs...)
+        push!(plots, plot)
+    end
+
+    return plots
+end
+
+function makie_points(coordinates)
+    if size(coordinates, 1) == 2
+        return [Makie.Point3f(coordinates[1, particle], coordinates[2, particle], 0)
+                for particle in axes(coordinates, 2)]
+    elseif size(coordinates, 1) == 3
+        return [Makie.Point3f(coordinates[1, particle], coordinates[2, particle],
+                              coordinates[3, particle])
+                for particle in axes(coordinates, 2)]
+    end
+
+    throw(ArgumentError("Makie visualization is only supported in two or three dimensions"))
+end
+
+end # module

--- a/ext/TrixiParticlesMakieExt.jl
+++ b/ext/TrixiParticlesMakieExt.jl
@@ -3,6 +3,8 @@ module TrixiParticlesMakieExt
 using Makie
 using TrixiParticles
 
+import TrixiParticles: trixi2makie, trixi2makie!
+
 const TP = TrixiParticles
 
 function default_system_color(system, system_index)
@@ -37,22 +39,85 @@ end
 
 @inline style_value(style, system, system_index) = style
 
-function TP.trixi2makie(scene, solution::TP.TrixiParticlesODESolution;
-                        frame=lastindex(solution.u), kwargs...)
-    v_ode, u_ode = solution.u[frame].x
-    semi = solution.prob.p.semi
+"""
+    trixi2makie(solution; frame=Makie.automatic, kwargs...)
+    trixi2makie(v_ode, u_ode, semi; kwargs...)
 
-    return TP.trixi2makie(scene, v_ode, u_ode, semi; kwargs...)
+Plot a TrixiParticles solution using Makie. See `TrixiParticles.trixi2makie` for details.
+"""
+Makie.@recipe Trixi2Makie begin
+    "Frame of the ODE solution to plot. `Makie.automatic` selects the last frame."
+    frame = Makie.automatic
+    "Indices of the systems to plot. `Makie.automatic` selects all systems."
+    system_indices = Makie.automatic
+    "A color, vector indexed by system number, or `(system, index)` function."
+    system_colors = default_system_color
+    "A size scale, vector indexed by system number, or `(system, index)` function."
+    marker_size_scales = default_marker_size_scale
+    Makie.documented_attributes(Makie.MeshScatter)...
+    marker = Makie.automatic
+    markerspace = :data
 end
 
-function TP.trixi2makie(scene, v_ode::AbstractArray, u_ode::AbstractArray,
-                        semi::TP.Semidiscretization;
-                        system_indices=eachindex(semi.systems),
-                        system_colors=default_system_color,
-                        marker_size_scales=default_marker_size_scale,
-                        kwargs...)
-    plots = Any[]
-    marker = Makie.Sphere(Makie.Point3f(0), 0.5f0)
+Makie.plottype(::TP.TrixiParticlesODESolution) = Trixi2Makie
+function Makie.plottype(::AbstractArray, ::AbstractArray, ::TP.Semidiscretization)
+    return Trixi2Makie
+end
+
+# Avoid the generic SciMLBase Makie conversion for ODE solutions after `plottype` selects
+# this recipe.
+function Makie.convert_arguments(::Type{<:Trixi2Makie},
+                                 solution::TP.TrixiParticlesODESolution)
+    return (solution,)
+end
+
+function visualization_state(args::Tuple{TP.TrixiParticlesODESolution}, frame)
+    solution = only(args)
+    frame_index = frame isa Makie.Automatic ? lastindex(solution.u) : frame
+    v_ode, u_ode = solution.u[frame_index].x
+    return v_ode, u_ode, solution.prob.p.semi
+end
+
+function visualization_state(args::Tuple{<:AbstractArray, <:AbstractArray,
+                                         <:TP.Semidiscretization}, frame)
+    return args
+end
+
+function semidiscretization(args::Tuple{TP.TrixiParticlesODESolution})
+    return only(args).prob.p.semi
+end
+
+function semidiscretization(args::Tuple{<:AbstractArray, <:AbstractArray,
+                                        <:TP.Semidiscretization})
+    return last(args)
+end
+
+function Makie.preferred_axis_type(plot::Trixi2Makie)
+    semi = semidiscretization(plot.args[])
+    ndims_ = ndims(first(semi.systems))
+
+    if ndims_ == 2
+        return Makie.Axis
+    elseif ndims_ == 3
+        return Makie.Axis3
+    end
+
+    throw(ArgumentError("Makie visualization is only supported in two or three dimensions"))
+end
+
+function Makie.preferred_axis_attributes(::Type{Makie.Axis}, ::Trixi2Makie)
+    return (; aspect=Makie.DataAspect())
+end
+
+function Makie.preferred_axis_attributes(::Type{Makie.Axis3}, ::Trixi2Makie)
+    return (; aspect=:data)
+end
+
+function Makie.plot!(plot::Trixi2Makie)
+    v_ode, u_ode, semi = visualization_state(plot.args[], plot.frame[])
+    system_indices = plot.system_indices[]
+    system_indices isa Makie.Automatic && (system_indices = eachindex(semi.systems))
+
     for system_index in system_indices
         system = semi.systems[system_index]
         particles = TP.eachparticle(system)
@@ -60,31 +125,37 @@ function TP.trixi2makie(scene, v_ode::AbstractArray, u_ode::AbstractArray,
 
         u = TP.wrap_u(u_ode, system, semi)
         coordinates = Array(TP.active_coordinates(u, system))
-        points = makie_points(coordinates)
         spacing = TP.particle_spacing(system, first(particles))
-        color = style_value(system_colors, system, system_index)
-        marker_size_scale = style_value(marker_size_scales, system, system_index)
+        color = style_value(plot.system_colors[], system, system_index)
+        marker_size_scale = style_value(plot.marker_size_scales[], system, system_index)
+        marker = plot.marker[]
 
-        plot = Makie.meshscatter!(scene, points; marker,
-                                  markersize=marker_size_scale * spacing,
-                                  color, kwargs...)
-        push!(plots, plot)
+        if ndims(system) == 2
+            marker isa Makie.Automatic && (marker = Makie.Circle(Makie.Point2f(0), 0.5f0))
+            points = makie_points(coordinates, Val(2))
+            Makie.meshscatter!(plot, plot.attributes, points; marker,
+                               markersize=marker_size_scale * spacing, color)
+        else
+            marker isa Makie.Automatic &&
+                (marker = Makie.Sphere(Makie.Point3f(0), 0.5f0))
+            points = makie_points(coordinates, Val(3))
+            Makie.meshscatter!(plot, plot.attributes, points; marker,
+                               markersize=marker_size_scale * spacing, color)
+        end
     end
 
-    return plots
+    return plot
 end
 
-function makie_points(coordinates)
-    if size(coordinates, 1) == 2
-        return [Makie.Point3f(coordinates[1, particle], coordinates[2, particle], 0)
-                for particle in axes(coordinates, 2)]
-    elseif size(coordinates, 1) == 3
-        return [Makie.Point3f(coordinates[1, particle], coordinates[2, particle],
-                              coordinates[3, particle])
-                for particle in axes(coordinates, 2)]
-    end
+function makie_points(coordinates, ::Val{2})
+    return [Makie.Point2f(coordinates[1, particle], coordinates[2, particle])
+            for particle in axes(coordinates, 2)]
+end
 
-    throw(ArgumentError("Makie visualization is only supported in two or three dimensions"))
+function makie_points(coordinates, ::Val{3})
+    return [Makie.Point3f(coordinates[1, particle], coordinates[2, particle],
+                          coordinates[3, particle])
+            for particle in axes(coordinates, 2)]
 end
 
 end # module

--- a/ext/TrixiParticlesMakieExt.jl
+++ b/ext/TrixiParticlesMakieExt.jl
@@ -118,6 +118,10 @@ function Makie.plot!(plot::Trixi2Makie)
     system_indices = plot.system_indices[]
     system_indices isa Makie.Automatic && (system_indices = eachindex(semi.systems))
 
+    if ndims(first(semi.systems)) == 3
+        return plot_3d!(plot, u_ode, semi, system_indices)
+    end
+
     for system_index in system_indices
         system = semi.systems[system_index]
         particles = TP.eachparticle(system)
@@ -130,19 +134,43 @@ function Makie.plot!(plot::Trixi2Makie)
         marker_size_scale = style_value(plot.marker_size_scales[], system, system_index)
         marker = plot.marker[]
 
-        if ndims(system) == 2
-            marker isa Makie.Automatic && (marker = Makie.Circle(Makie.Point2f(0), 0.5f0))
-            points = makie_points(coordinates, Val(2))
-            Makie.meshscatter!(plot, plot.attributes, points; marker,
-                               markersize=marker_size_scale * spacing, color)
-        else
-            marker isa Makie.Automatic &&
-                (marker = Makie.Sphere(Makie.Point3f(0), 0.5f0))
-            points = makie_points(coordinates, Val(3))
-            Makie.meshscatter!(plot, plot.attributes, points; marker,
-                               markersize=marker_size_scale * spacing, color)
-        end
+        marker isa Makie.Automatic && (marker = Makie.Circle(Makie.Point2f(0), 0.5f0))
+        points = makie_points(coordinates, Val(2))
+        Makie.meshscatter!(plot, plot.attributes, points; marker,
+                           markersize=marker_size_scale * spacing, color)
     end
+
+    return plot
+end
+
+function plot_3d!(plot, u_ode, semi, system_indices)
+    # CairoMakie depth-sorts particles within one MeshScatter, but not across separate plots.
+    points = Makie.Point3f[]
+    colors = Makie.RGBAf[]
+    marker_sizes = Float64[]
+
+    for system_index in system_indices
+        system = semi.systems[system_index]
+        particles = TP.eachparticle(system)
+        isempty(particles) && continue
+
+        u = TP.wrap_u(u_ode, system, semi)
+        coordinates = Array(TP.active_coordinates(u, system))
+        system_points = makie_points(coordinates, Val(3))
+        spacing = TP.particle_spacing(system, first(particles))
+        color = Makie.to_color(style_value(plot.system_colors[], system, system_index))
+        marker_size_scale = style_value(plot.marker_size_scales[], system, system_index)
+
+        append!(points, system_points)
+        append!(colors, Iterators.repeated(color, length(system_points)))
+        append!(marker_sizes,
+                Iterators.repeated(marker_size_scale * spacing, length(system_points)))
+    end
+
+    marker = plot.marker[]
+    marker isa Makie.Automatic && (marker = Makie.Sphere(Makie.Point3f(0), 0.5f0))
+    Makie.meshscatter!(plot, plot.attributes, points; marker,
+                       markersize=marker_sizes, color=colors)
 
     return plot
 end

--- a/src/TrixiParticles.jl
+++ b/src/TrixiParticles.jl
@@ -101,7 +101,7 @@ export PrescribedMotion, OscillatingMotion2D
 export RCRWindkesselModel
 export examples_dir, validation_dir
 export trixi2vtk, vtk2trixi
-export trixi2makie
+export trixi2makie, trixi2makie!
 export RectangularTank, RectangularShape, SphereShape, ComplexShape
 export ParticlePackingSystem, SignedDistanceField
 export WindingNumberHormann, WindingNumberJacobson

--- a/src/TrixiParticles.jl
+++ b/src/TrixiParticles.jl
@@ -64,6 +64,7 @@ include("preprocessing/preprocessing.jl")
 include("io/io.jl")
 include("general/restart.jl")
 include("visualization/recipes_plots.jl")
+include("visualization/makie.jl")
 
 export Semidiscretization, semidiscretize, restart_with!
 export PairsNHSHandler, SharedNHSHandler
@@ -100,6 +101,7 @@ export PrescribedMotion, OscillatingMotion2D
 export RCRWindkesselModel
 export examples_dir, validation_dir
 export trixi2vtk, vtk2trixi
+export trixi2makie
 export RectangularTank, RectangularShape, SphereShape, ComplexShape
 export ParticlePackingSystem, SignedDistanceField
 export WindingNumberHormann, WindingNumberJacobson

--- a/src/visualization/makie.jl
+++ b/src/visualization/makie.jl
@@ -1,14 +1,20 @@
 """
-    trixi2makie(scene, solution; frame=lastindex(solution.u), kwargs...)
-    trixi2makie(scene, v_ode, u_ode, semi; kwargs...)
+    trixi2makie(solution; frame=Makie.automatic, kwargs...)
+    trixi2makie(v_ode, u_ode, semi; kwargs...)
+    trixi2makie!(axis, args...; kwargs...)
 
-Plot a TrixiParticles solution in a Makie `Scene` or `LScene` as physically sized particle
-spheres. The first method plots one frame of an ODE solution, while the second accepts the
-position and state arrays explicitly. This particle-level view is intended for diagnostics;
-fluid surface reconstruction requires additional post-processing.
+Plot a TrixiParticles solution with Makie using physically sized particle markers. The first
+method plots one frame of an ODE solution, while the second accepts the position and state
+arrays explicitly. Use `trixi2makie!` to add the plot to an existing Makie axis.
+
+Makie's generic `plot` and `plot!` functions support the same arguments, so `plot(solution)`
+and `plot!(axis, solution)` use this recipe as well. This particle-level view is intended for
+diagnostics; fluid surface reconstruction requires additional post-processing.
 
 This function is available after loading Makie or one of its backends, such as CairoMakie,
 GLMakie, or RayMakie. See the visualization documentation for the supported keyword
 arguments.
 """
 function trixi2makie end
+
+function trixi2makie! end

--- a/src/visualization/makie.jl
+++ b/src/visualization/makie.jl
@@ -1,0 +1,14 @@
+"""
+    trixi2makie(scene, solution; frame=lastindex(solution.u), kwargs...)
+    trixi2makie(scene, v_ode, u_ode, semi; kwargs...)
+
+Plot a TrixiParticles solution in a Makie `Scene` or `LScene` as physically sized particle
+spheres. The first method plots one frame of an ODE solution, while the second accepts the
+position and state arrays explicitly. This particle-level view is intended for diagnostics;
+fluid surface reconstruction requires additional post-processing.
+
+This function is available after loading Makie or one of its backends, such as CairoMakie,
+GLMakie, or RayMakie. See the visualization documentation for the supported keyword
+arguments.
+"""
+function trixi2makie end

--- a/test/unittest.jl
+++ b/test/unittest.jl
@@ -9,4 +9,5 @@
     include("preprocessing/preprocessing.jl")
     include("io/write_vtk.jl")
     include("io/read_vtk.jl")
+    include("visualization/makie.jl")
 end;

--- a/test/visualization/makie.jl
+++ b/test/visualization/makie.jl
@@ -53,4 +53,25 @@ using CairoMakie
     @test axis isa Axis3
     @test only(plot_object.plots) isa CairoMakie.MeshScatter
     @test length(only(plot_object.plots)[1][]) == nparticles(fluid_system_3d)
+
+    initial_condition_3d_2 = RectangularShape(0.1, (2, 2, 2), (0.3, 0.0, 0.0);
+                                              density=1.0)
+    fluid_system_3d_2 = WeaklyCompressibleSPHSystem(initial_condition_3d_2;
+                                                    smoothing_kernel=SchoenbergCubicSplineKernel{3}(),
+                                                    smoothing_length=0.1,
+                                                    density_calculator=SummationDensity(),
+                                                    state_equation=nothing)
+    semi_3d_2 = Semidiscretization(fluid_system_3d, fluid_system_3d_2)
+    ode_3d_2 = semidiscretize(semi_3d_2, (0.0, 0.01))
+    v_ode_3d_2, u_ode_3d_2 = ode_3d_2.u0.x
+
+    _, _, plot_object = plot(v_ode_3d_2, u_ode_3d_2, semi_3d_2;
+                             system_colors=[:blue, :orange],
+                             marker_size_scales=[0.8, 0.5])
+    @test length(plot_object.plots) == 1
+    meshscatter = only(plot_object.plots)
+    @test length(meshscatter[1][]) ==
+          nparticles(fluid_system_3d) + nparticles(fluid_system_3d_2)
+    @test length(meshscatter.color[]) == length(meshscatter[1][])
+    @test length(meshscatter.markersize[]) == length(meshscatter[1][])
 end

--- a/test/visualization/makie.jl
+++ b/test/visualization/makie.jl
@@ -1,10 +1,9 @@
 using CairoMakie
 
 @testset verbose=true "Makie Extension" begin
-    initial_condition = RectangularShape(0.1, (2, 2, 2), (0.0, 0.0, 0.0);
-                                         density=1.0)
+    initial_condition = RectangularShape(0.1, (2, 2), (0.0, 0.0); density=1.0)
     fluid_system = WeaklyCompressibleSPHSystem(initial_condition;
-                                               smoothing_kernel=SchoenbergCubicSplineKernel{3}(),
+                                               smoothing_kernel=SchoenbergCubicSplineKernel{2}(),
                                                smoothing_length=0.1,
                                                density_calculator=SummationDensity(),
                                                state_equation=nothing)
@@ -12,12 +11,46 @@ using CairoMakie
     ode = semidiscretize(semi, (0.0, 0.01))
     v_ode, u_ode = ode.u0.x
 
-    figure = Figure(; size=(320, 240))
-    axis = LScene(figure[1, 1]; show_axis=false)
-    plots = trixi2makie(axis, v_ode, u_ode, semi)
+    makie_extension = Base.get_extension(TrixiParticles, :TrixiParticlesMakieExt)
+    @test makie_extension !== nothing
 
-    @test Base.get_extension(TrixiParticles, :TrixiParticlesMakieExt) !== nothing
-    @test length(plots) == 1
-    @test only(plots) isa CairoMakie.MeshScatter
-    @test length(only(plots)[1][]) == nparticles(fluid_system)
+    figure, axis, plot_object = plot(v_ode, u_ode, semi)
+    @test figure isa Figure
+    @test axis isa Axis
+    @test length(plot_object.plots) == 1
+    @test only(plot_object.plots) isa CairoMakie.MeshScatter
+    @test length(only(plot_object.plots)[1][]) == nparticles(fluid_system)
+
+    figure = Figure(; size=(320, 240))
+    axis = Axis(figure[1, 1])
+    plot_object = trixi2makie!(axis, v_ode, u_ode, semi)
+    @test plot_object isa makie_extension.Trixi2Makie
+
+    solution = TrixiParticles.SciMLBase.build_solution(ode, :NoAlgorithm,
+                                                       [first(ode.tspan)], [ode.u0])
+    figure, axis, plot_object = plot(solution)
+    @test figure isa Figure
+    @test axis isa Axis
+    @test plot_object isa makie_extension.Trixi2Makie
+
+    figure = Figure(; size=(320, 240))
+    axis = Axis(figure[1, 1])
+    @test plot!(axis, solution) isa makie_extension.Trixi2Makie
+
+    initial_condition_3d = RectangularShape(0.1, (2, 2, 2), (0.0, 0.0, 0.0);
+                                            density=1.0)
+    fluid_system_3d = WeaklyCompressibleSPHSystem(initial_condition_3d;
+                                                  smoothing_kernel=SchoenbergCubicSplineKernel{3}(),
+                                                  smoothing_length=0.1,
+                                                  density_calculator=SummationDensity(),
+                                                  state_equation=nothing)
+    semi_3d = Semidiscretization(fluid_system_3d)
+    ode_3d = semidiscretize(semi_3d, (0.0, 0.01))
+    v_ode_3d, u_ode_3d = ode_3d.u0.x
+
+    figure, axis, plot_object = plot(v_ode_3d, u_ode_3d, semi_3d)
+    @test figure isa Figure
+    @test axis isa Axis3
+    @test only(plot_object.plots) isa CairoMakie.MeshScatter
+    @test length(only(plot_object.plots)[1][]) == nparticles(fluid_system_3d)
 end

--- a/test/visualization/makie.jl
+++ b/test/visualization/makie.jl
@@ -1,0 +1,23 @@
+using CairoMakie
+
+@testset verbose=true "Makie Extension" begin
+    initial_condition = RectangularShape(0.1, (2, 2, 2), (0.0, 0.0, 0.0);
+                                         density=1.0)
+    fluid_system = WeaklyCompressibleSPHSystem(initial_condition;
+                                               smoothing_kernel=SchoenbergCubicSplineKernel{3}(),
+                                               smoothing_length=0.1,
+                                               density_calculator=SummationDensity(),
+                                               state_equation=nothing)
+    semi = Semidiscretization(fluid_system)
+    ode = semidiscretize(semi, (0.0, 0.01))
+    v_ode, u_ode = ode.u0.x
+
+    figure = Figure(; size=(320, 240))
+    axis = LScene(figure[1, 1]; show_axis=false)
+    plots = trixi2makie(axis, v_ode, u_ode, semi)
+
+    @test Base.get_extension(TrixiParticles, :TrixiParticlesMakieExt) !== nothing
+    @test length(plots) == 1
+    @test only(plots) isa CairoMakie.MeshScatter
+    @test length(only(plots)[1][]) == nparticles(fluid_system)
+end


### PR DESCRIPTION
## Summary
- add Makie as a weak dependency and expose `trixi2makie` through a package extension
- render selected 2D or 3D particle systems from solution frames or explicit state arrays
- support configurable per-system colors and marker-size scales
- document the API and add a focused CairoMakie extension test

## Testing
- focused Makie extension test: 4/4 passed
- `TRIXIPARTICLES_TEST=unit JULIA_NUM_THREADS=8 julia +release --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: passed\n- JuliaFormatter 2.1.1 and `git diff --check`: passed\n\nThe full documentation build was attempted. It loaded and expanded the new Makie extension, but current `main` fails later in `tut_2d_geometry` because the referenced `curved_pipe_outer_2d.asc`, `curved_pipe_channel_2d.asc`, and `coastline_profile_2d.asc` files are absent. This PR does not modify that tutorial.


<img width="1800" height="1140" alt="image" src="https://github.com/user-attachments/assets/40aea9b6-f2d6-4821-b45a-6a295e76dca3" />
<img width="1800" height="1230" alt="image" src="https://github.com/user-attachments/assets/7280101d-cc68-46f3-b04b-8502ce116876" />
